### PR TITLE
Formatting fix for rancher-compose.yml in zookeeper

### DIFF
--- a/templates/zookeeper/0/rancher-compose.yml
+++ b/templates/zookeeper/0/rancher-compose.yml
@@ -6,7 +6,7 @@
   minimum_rancher_version: v0.46.0
   uuid: zookeeper-0
   questions:
-    variable: "scale"
+    - variable: "scale"
       description: "Number of Zookeeper nodes. Note: it should be an odd number"
       label: "Number of Nodes:"
       required: true


### PR DESCRIPTION
Spotted the following error in my rancher server logs: 

```
^[[Atime="2015-12-01T14:39:44Z" level=error msg="Error unmarshalling rancher-compose.yml under template: zookeeper/0, error: yaml: line 9: did not find expected key"
```

Led me to this file, i've adjusted the formatting, now passes as valid yaml. 
