### PR TITLE
Make glusterfs compatible with systems that don't have fuse loaded

### DIFF
--- a/templates/convoy-gluster/0/docker-compose.yml
+++ b/templates/convoy-gluster/0/docker-compose.yml
@@ -1,22 +1,23 @@
 convoy-gluster:
-    labels:
-        io.rancher.container.create_agent: 'true'
-        io.rancher.scheduler.global: 'true'
-        io.rancher.scheduler.affinity:host_label_soft: ${HOST_LABEL}
-    privileged: true
-    pid: host
-    volumes:
-        - /proc:/host/proc
-        - /run:/host/run
-        - /etc/docker/plugins:/etc/docker/plugins
-    external_links:
-        - "${GLUSTERFS_SERVICE}:glusterfs"
-    image: rancher/convoy-agent:v0.1.0
-    command: volume-agent-glusterfs
+  labels:
+    io.rancher.container.create_agent: 'true'
+    io.rancher.scheduler.global: 'true'
+    io.rancher.scheduler.affinity:host_label_soft: ${HOST_LABEL}
+  privileged: true
+  pid: host
+  volumes:
+    - /lib/modules:/lib/modules:ro
+    - /proc:/host/proc
+    - /run:/host/run
+    - /etc/docker/plugins:/etc/docker/plugins
+  external_links:
+    - "${GLUSTERFS_SERVICE}:glusterfs"
+  image: rancher/convoy-agent:v0.1.1
+  command: volume-agent-glusterfs
 
 convoy-gluster-storagepool:
-    labels:
-      io.rancher.container.create_agent: 'true'
-      io.rancher.scheduler.affinity:host_label_soft: ${HOST_LABEL}
-    image: rancher/convoy-agent:v0.1.0
-    command: storagepool-agent
+  labels:
+    io.rancher.container.create_agent: 'true'
+    io.rancher.scheduler.affinity:host_label_soft: ${HOST_LABEL}
+  image: rancher/convoy-agent:v0.1.0
+  command: storagepool-agent

--- a/templates/glusterfs/0/docker-compose.yml
+++ b/templates/glusterfs/0/docker-compose.yml
@@ -1,7 +1,5 @@
 glusterfs-server:
   image: rancher/glusterfs:v0.1.3
-  devices:
-    - /dev/fuse:/dev/fuse:rwm
   cap_add:
     - SYS_ADMIN
   volumes_from:


### PR DESCRIPTION
I couldn't help but fix the whitespace.  It's best to disable whitespace in the diff to see what really changed: https://github.com/rancher/rancher-catalog/pull/57/files?w=0
