### PR TITLE
Upgrade convoy-agent image

### DIFF
--- a/templates/convoy-gluster/0/docker-compose.yml
+++ b/templates/convoy-gluster/0/docker-compose.yml
@@ -8,16 +8,16 @@ convoy-gluster:
   volumes:
     - /lib/modules:/lib/modules:ro
     - /proc:/host/proc
-    - /run:/host/run
+    - /var/run:/host/var/run
     - /etc/docker/plugins:/etc/docker/plugins
   external_links:
     - "${GLUSTERFS_SERVICE}:glusterfs"
-  image: rancher/convoy-agent:v0.1.1
+  image: rancher/convoy-agent:v0.1.2
   command: volume-agent-glusterfs
 
 convoy-gluster-storagepool:
   labels:
     io.rancher.container.create_agent: 'true'
     io.rancher.scheduler.affinity:host_label_soft: ${HOST_LABEL}
-  image: rancher/convoy-agent:v0.1.0
+  image: rancher/convoy-agent:v0.1.2
   command: storagepool-agent


### PR DESCRIPTION
This change corresponds to changes in convoy-agent to use a newer
version of share-mnt and fix a naming issue with the convoy socket.
