### PR TITLE
Fixed a typo in MongoDB config.yml

### DIFF
--- a/templates/MongoDB/config.yml
+++ b/templates/MongoDB/config.yml
@@ -2,4 +2,4 @@ name: MongoDB
 description: |
   MongoDB Replica Set.
 version: 3.0.0-rancher1
-category: Databasae
+category: Database


### PR DESCRIPTION
Fixed a typo in MongoDB template file config.yml. Solves #76. Thank you.

```
Databasae -> Database
```
