### PR TITLE
All DNS templates to use v0.2.1 image

### DIFF
--- a/templates/cloudflare/1/docker-compose.yml
+++ b/templates/cloudflare/1/docker-compose.yml
@@ -1,0 +1,13 @@
+cloudflare:
+  image: rancher/external-dns:v0.2.1
+  command: -provider=cloudflare
+  expose: 
+   - 1000
+  environment:
+    CLOUDFLARE_EMAIL: ${CLOUDFLARE_EMAIL}
+    CLOUDFLARE_KEY: ${CLOUDFLARE_KEY}
+    ROOT_DOMAIN: ${ROOT_DOMAIN}
+    TTL: ${TTL}
+  labels:
+    io.rancher.container.create_agent: "true"
+    io.rancher.container.agent.role: "external-dns"

--- a/templates/cloudflare/1/rancher-compose.yml
+++ b/templates/cloudflare/1/rancher-compose.yml
@@ -1,0 +1,37 @@
+.catalog:
+  name: "CloudFlare DNS"
+  version: "v0.2.1-rancher1"
+  description: "Rancher External DNS service powered by CloudFlare. Requires Rancher version 0.44.0"
+  uuid: cloudflare-1
+  minimum_rancher_version: v0.44.0
+  questions:
+    - variable: "CLOUDFLARE_EMAIL"
+      label: "CloudFlare email address"
+      description: "Email address associated with your CloudFlare account"
+      type: "string"
+      required: true
+    - variable: "CLOUDFLARE_KEY"
+      label: "CloudFlare API key"
+      description: "API key for your CloudFlare account"
+      type: "string"
+      required: true
+    - variable: "ROOT_DOMAIN"
+      label: "Domain"
+      description: "The DNS zone (domain) managed by CloudFlare. DNS entries will be created for <service>.<stack>.<environment>.<domain>"
+      type: "string"
+      required: true
+    - variable: "TTL"
+      label: "TTL"
+      description: "The resource record cache time to live (TTL), in seconds (minimum 120)"
+      type: "int"
+      default: 300
+      required: false
+
+cloudflare:
+  health_check:
+    port: 1000
+    interval: 2000
+    unhealthy_threshold: 3
+    request_line: GET / HTTP/1.0
+    healthy_threshold: 2
+    response_timeout: 2000

--- a/templates/cloudflare/config.yml
+++ b/templates/cloudflare/config.yml
@@ -1,5 +1,5 @@
 name: CloudFlare DNS
 description: |
   Rancher External DNS service powered by CloudFlare
-version: v0.1.9-rancher1
+version: v0.2.1-rancher1
 category: "Rancher services"

--- a/templates/dnsimple/1/docker-compose.yml
+++ b/templates/dnsimple/1/docker-compose.yml
@@ -1,0 +1,13 @@
+dnsimple:
+  image: rancher/external-dns:v0.2.1
+  command: --provider dnsimple
+  expose: 
+   - 1000
+  environment:
+    DNSIMPLE_TOKEN: ${DNSIMPLE_TOKEN}
+    DNSIMPLE_EMAIL: ${DNSIMPLE_EMAIL}
+    ROOT_DOMAIN: ${ROOT_DOMAIN}
+    TTL: ${TTL}
+  labels:
+    io.rancher.container.create_agent: "true"
+    io.rancher.container.agent.role: "external-dns"

--- a/templates/dnsimple/1/rancher-compose.yml
+++ b/templates/dnsimple/1/rancher-compose.yml
@@ -1,0 +1,37 @@
+.catalog:
+  name: "DNSimple DNS"
+  version: "v0.2.1-rancher1"
+  description: "Rancher External DNS service powered by DNSimple. Requires Rancher version 0.44.0"
+  uuid: dnsimple-1
+  minimum_rancher_version: v0.44.0
+  questions:
+    - variable: "DNSIMPLE_EMAIL"
+      label: "DNSimple account email address"
+      description: "EMail address associated with your DNSimple account"
+      type: "string"
+      required: true
+    - variable: "DNSIMPLE_TOKEN"
+      label: "DNSimple API token"
+      description: "API token for your DNSimple account"
+      type: "string"
+      required: true
+    - variable: "ROOT_DOMAIN"
+      label: "Root domain"
+      description: "DNS entries will be created for <service>.<stack>.<environment>.<root domain>"
+      type: "string"
+      required: true
+    - variable: "TTL"
+      label: "TTL"
+      description: "The resource record cache time to live (TTL), in seconds"
+      type: "int"
+      default: 300
+      required: false
+
+dnsimple:
+  health_check:
+    port: 1000
+    interval: 2000
+    unhealthy_threshold: 3
+    request_line: GET / HTTP/1.0
+    healthy_threshold: 2
+    response_timeout: 2000

--- a/templates/dnsimple/config.yml
+++ b/templates/dnsimple/config.yml
@@ -1,5 +1,5 @@
 name: DNSimple DNS
 description: |
   Rancher External DNS service powered by DNSimple
-version: v0.1.9-rancher1
+version: v0.2.1-rancher1
 category: "Rancher services"

--- a/templates/pointhq/1/docker-compose.yml
+++ b/templates/pointhq/1/docker-compose.yml
@@ -1,0 +1,13 @@
+pointhq:
+  image: rancher/external-dns:v0.2.1
+  command: --provider pointhq
+  expose: 
+   - 1000
+  environment:
+    POINTHQ_TOKEN: ${POINTHQ_TOKEN}
+    POINTHQ_EMAIL: ${POINTHQ_EMAIL}
+    ROOT_DOMAIN: ${ROOT_DOMAIN}
+    TTL: ${TTL}
+  labels:
+    io.rancher.container.create_agent: "true"
+    io.rancher.container.agent.role: "external-dns"

--- a/templates/pointhq/1/rancher-compose.yml
+++ b/templates/pointhq/1/rancher-compose.yml
@@ -1,0 +1,37 @@
+.catalog:
+  name: "PointHQ DNS"
+  version: "v0.2.1-rancher1"
+  description: "Rancher External DNS service powered by PointHQ. Requires Rancher version 0.44.0"
+  uuid: pointhq-1
+  minimum_rancher_version: v0.44.0
+  questions:
+    - variable: "POINTHQ_EMAIL"
+      label: "PointHQ account email address"
+      description: "EMail address associated with your PointHQ account"
+      type: "string"
+      required: true
+    - variable: "POINTHQ_TOKEN"
+      label: "PointHQ API token"
+      description: "API token for your PointHQ account"
+      type: "string"
+      required: true
+    - variable: "ROOT_DOMAIN"
+      label: "Root domain"
+      description: "DNS entries will be created for <service>.<stack>.<environment>.<root domain>"
+      type: "string"
+      required: true
+    - variable: "TTL"
+      label: "TTL"
+      description: "The resource record cache time to live (TTL), in seconds"
+      type: "int"
+      default: 300
+      required: false
+
+pointhq:
+  health_check:
+    port: 1000
+    interval: 2000
+    unhealthy_threshold: 3
+    request_line: GET / HTTP/1.0
+    healthy_threshold: 2
+    response_timeout: 2000

--- a/templates/pointhq/config.yml
+++ b/templates/pointhq/config.yml
@@ -1,5 +1,5 @@
 name: PointHQ DNS
 description: |
   Rancher External DNS service powered by PointHQ
-version: v0.2.0-rancher1
+version: v0.2.1-rancher1
 category: "Rancher services"

--- a/templates/route53/3/docker-compose.yml
+++ b/templates/route53/3/docker-compose.yml
@@ -1,0 +1,13 @@
+route53:
+  image: rancher/external-dns:v0.2.1
+  expose: 
+   - 1000
+  environment:
+    AWS_ACCESS_KEY: ${AWS_ACCESS_KEY}
+    AWS_SECRET_KEY: ${AWS_SECRET_KEY}
+    AWS_REGION: ${AWS_REGION}
+    ROOT_DOMAIN: ${ROOT_DOMAIN}
+    TTL: ${TTL}
+  labels:
+    io.rancher.container.create_agent: "true"
+    io.rancher.container.agent.role: "external-dns"

--- a/templates/route53/3/rancher-compose.yml
+++ b/templates/route53/3/rancher-compose.yml
@@ -1,0 +1,43 @@
+.catalog:
+  name: "Route53 DNS"
+  version: "v0.2.1-rancher1"
+  description: "Rancher External DNS service powered by Amazon Route53. Requires Rancher version 0.44.0"
+  uuid: route53-3
+  minimum_rancher_version: v0.44.0
+  questions:
+    - variable: "AWS_ACCESS_KEY"
+      label: "AWS access key"
+      description: "Access key to your AWS account"
+      type: "string"
+      required: true
+    - variable: "AWS_SECRET_KEY"
+      label: "AWS secret key"
+      description: "Secret key to your AWS account"
+      type: "string"
+      required: true
+    - variable: "AWS_REGION"
+      label: "AWS region"
+      description: "AWS region name"
+      type: "string"
+      default: "us-west-2"
+      required: true
+    - variable: "ROOT_DOMAIN"
+      label: "Hosted zone"
+      description: "Route53 hosted zone name (zone has to be pre-created). DNS entries will be created for <service>.<stack>.<environment>.<hosted zone>"
+      type: "string"
+      required: true
+    - variable: "TTL"
+      label: "TTL"
+      description: "The resource record cache time to live (TTL), in seconds"
+      type: "int"
+      default: 300
+      required: false
+
+route53:
+  health_check:
+    port: 1000
+    interval: 2000
+    unhealthy_threshold: 3
+    request_line: GET / HTTP/1.0
+    healthy_threshold: 2
+    response_timeout: 2000

--- a/templates/route53/config.yml
+++ b/templates/route53/config.yml
@@ -1,5 +1,5 @@
 name: Route53 DNS
 description: |
   Rancher External DNS service powered by Amazon Route53
-version: v0.1.7-rancher1
+version: v0.2.1-rancher1
 category: "Rancher services"


### PR DESCRIPTION
Yet to release v0.2.1 external-dns template, so hold off merging this PR.

@cloudnautique could you please review to see if anything is missing?
