### PR TITLE
Adds HOST_LABEL option to glusterfs stack

### DIFF
--- a/templates/glusterfs/0/docker-compose.yml
+++ b/templates/glusterfs/0/docker-compose.yml
@@ -7,6 +7,7 @@ glusterfs-server:
   labels:
     io.rancher.container.hostname_override: container_name
     io.rancher.sidekicks: glusterfs-peer,glusterfs-data,glusterfs-volume-create
+    io.rancher.scheduler.affinity:host_label_soft: ${HOST_LABEL}
   command: "glusterd -p /var/run/gluster.pid -N"
 glusterfs-peer:
   image: rancher/glusterfs:v0.1.3
@@ -15,6 +16,7 @@ glusterfs-peer:
     - glusterfs-data
   labels:
     io.rancher.container.hostname_override: container_name
+    io.rancher.scheduler.affinity:host_label_soft: ${HOST_LABEL}
   command: /opt/rancher/peerprobe.sh
 glusterfs-data:
   image: rancher/glusterfs:v0.1.3
@@ -24,6 +26,7 @@ glusterfs-data:
   labels:
     io.rancher.container.hostname_override: container_name
     io.rancher.container.start_once: true
+    io.rancher.scheduler.affinity:host_label_soft: ${HOST_LABEL}
 glusterfs-volume-create:
   image: rancher/glusterfs:v0.1.3
   command: /opt/rancher/replicated_volume_create.sh
@@ -33,3 +36,4 @@ glusterfs-volume-create:
   labels:
     io.rancher.container.hostname_override: container_name
     io.rancher.container.start_once: true
+    io.rancher.scheduler.affinity:host_label_soft: ${HOST_LABEL}

--- a/templates/glusterfs/0/rancher-compose.yml
+++ b/templates/glusterfs/0/rancher-compose.yml
@@ -10,6 +10,13 @@
       required: true
       default: "my_vol"
       type: "string"
+    - variable: "HOST_LABEL"
+      label: "Host label"
+      description: "Specify a Rancher host label here that will be used to determine where the GlusterFS service will be deployed"
+      type: "string"
+      default: glusterfs=true
+      required: true
+
 glusterfs-server:
   scale: 3
   metadata:


### PR DESCRIPTION
This PR adds a HOST_LABEL option to glusterfs stack to give to the users the possibility to choose in which hosts they want to put the containers of this stack.
