### PR TITLE
Elasticsearch v2.1.1 / Logstash v2.1.1 / Kibana v4.3.1 Rancher catalog templates

### DIFF
--- a/templates/elasticsearch/2/docker-compose.yml
+++ b/templates/elasticsearch/2/docker-compose.yml
@@ -1,0 +1,102 @@
+elasticsearch-masters:
+  labels:
+    io.rancher.container.hostname_override: container_name
+    io.rancher.sidekicks: elasticsearch-base-master,elasticsearch-datavolume-masters
+  image: rancher/elasticsearch-conf:v0.5.0
+elasticsearch-datavolume-masters:
+  labels:
+    elasticsearch.datanode.config.version: '0'
+    io.rancher.container.hostname_override: container_name
+    io.rancher.container.start_once: true
+  image: elasticsearch:2.1.1
+  volumes:
+    - /usr/share/elasticsearch/data
+  net: "container:elasticsearch-masters"
+  entrypoint: /bin/true
+elasticsearch-base-master:
+  labels:
+    elasticsearch.master.config.version: '0'
+    io.rancher.container.hostname_override: container_name
+  image: elasticsearch:2.1.1
+  volumes_from:
+    - elasticsearch-masters
+    - elasticsearch-datavolume-masters
+  net: "container:elasticsearch-masters"
+  entrypoint:
+    - /opt/rancher/bin/run.sh
+
+
+elasticsearch-datanodes:
+  labels:
+    io.rancher.container.hostname_override: container_name
+    io.rancher.sidekicks: elasticsearch-base-datanode,elasticsearch-datavolume-datanode
+    io.rancher.scheduler.affinity:container_label_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
+  links:
+    - elasticsearch-masters:es-masters
+  image: rancher/elasticsearch-conf:v0.5.0
+elasticsearch-datavolume-datanode:
+  labels:
+    elasticsearch.datanode.config.version: '0'
+    io.rancher.container.hostname_override: container_name
+    io.rancher.container.start_once: true
+  image: elasticsearch:2.1.1
+  volumes:
+    - /usr/share/elasticsearch/data
+  net: "container:elasticsearch-datanodes"
+  entrypoint: /bin/true
+elasticsearch-base-datanode:
+  labels:
+    elasticsearch.datanode.config.version: '0'
+    io.rancher.container.hostname_override: container_name
+  links:
+    - elasticsearch-masters:es-masters
+  image: elasticsearch:2.1.1
+  volumes_from:
+    - elasticsearch-datanodes
+    - elasticsearch-datavolume-datanode
+  net: "container:elasticsearch-datanodes"
+  entrypoint:
+    - /opt/rancher/bin/run.sh
+
+
+elasticsearch-clients:
+  labels:
+    io.rancher.container.hostname_override: container_name
+    io.rancher.sidekicks: elasticsearch-base-clients,elasticsearch-datavolume-clients
+  links:
+    - elasticsearch-masters:es-masters
+  image: rancher/elasticsearch-conf:v0.5.0
+elasticsearch-datavolume-clients:
+  labels:
+    elasticsearch.datanode.config.version: '0'
+    io.rancher.container.hostname_override: container_name
+    io.rancher.container.start_once: true
+  image: elasticsearch:2.1.1
+  volumes:
+    - /usr/share/elasticsearch/data
+  net: "container:elasticsearch-clients"
+  entrypoint: /bin/true
+elasticsearch-base-clients:
+  labels:
+    elasticsearch.client.config.version: '0'
+    io.rancher.container.hostname_override: container_name
+  image: elasticsearch:2.1.1
+  volumes_from:
+    - elasticsearch-clients
+    - elasticsearch-datavolume-clients
+  net: "container:elasticsearch-clients"
+  entrypoint:
+    - /opt/rancher/bin/run.sh
+
+
+kopf:
+  labels:
+    io.rancher.container.hostname_override: container_name
+  links:
+    - elasticsearch-clients:es-clients
+  image: rancher/kopf:v0.5.0
+  ports: 
+    - "80:80"
+  environment:
+    KOPF_SERVER_NAME: 'es.dev'
+    KOPF_ES_SERVERS: 'es-clients:9200'

--- a/templates/elasticsearch/2/rancher-compose.yml
+++ b/templates/elasticsearch/2/rancher-compose.yml
@@ -1,0 +1,37 @@
+.catalog:
+  name: "Elasticsearch"
+  version: "2.1.1-rancher1"
+  description: "Elasticsearch. You know, for search"
+  uuid: elasticsearch-1
+  questions:
+    - variable: cluster_name
+      description: "Unique name to assign to your Elasticsearch cluster."
+      label: "Cluster Name"
+      type: "string"
+      required: true
+      default: "es"
+elasticsearch-masters:
+  metadata:
+    elasticsearch:
+      yml:
+        cluster.name: "${cluster_name}"
+        node.name: "$${HOSTNAME}"
+        node.data: "false"
+        node.master: "true"
+elasticsearch-datanodes:
+  metadata:
+    elasticsearch:
+      yml:
+        cluster.name: "${cluster_name}"
+        node.name: "$${HOSTNAME}"
+        node.data: "true"
+        node.master: "false"
+        http.enabled: "false"
+elasticsearch-clients:
+  metadata:
+    elasticsearch:
+      yml:
+       cluster.name: "${cluster_name}"
+       node.name: "$${HOSTNAME}"
+       node.data: "false"
+       node.master: "false"

--- a/templates/elasticsearch/config.yml
+++ b/templates/elasticsearch/config.yml
@@ -1,5 +1,5 @@
 name: Elasticsearch
 description: |
   Elasticsearch, you know for search!
-version: 1.7.3-rancher1
+version: 2.1.1-rancher1
 category: ELK

--- a/templates/kibana/1/docker-compose.yml
+++ b/templates/kibana/1/docker-compose.yml
@@ -1,0 +1,33 @@
+kibana-vip:
+  ports:
+  - 80:80
+  restart: always
+  tty: true
+  image: rancher/load-balancer-service
+  links:
+  - nginx-proxy:kibana4
+  stdin_open: true
+nginx-proxy-conf:
+  image: rancher/nginx-conf:v0.2.0
+  command: "-backend=rancher --prefix=/2015-07-25"
+  labels:
+    io.rancher.container.hostname_override: container_name
+nginx-proxy:
+  image: rancher/nginx:v1.9.4-3
+  volumes_from:
+    - nginx-proxy-conf
+  labels:
+    io.rancher.container.hostname_override: container_name
+    io.rancher.sidekicks: nginx-proxy-conf,kibana4
+  external_links:
+    - ${elasticsearch_source}:elasticsearch
+kibana4:
+  restart: always
+  tty: true
+  image: kibana:4.3.1
+  net: "container:nginx-proxy"
+  stdin_open: true
+  environment:
+    ELASTICSEARCH_URL: "http://elasticsearch:9200"
+  labels:
+    io.rancher.container.hostname_override: container_name

--- a/templates/kibana/1/rancher-compose.yml
+++ b/templates/kibana/1/rancher-compose.yml
@@ -1,0 +1,18 @@
+.catalog:
+  name: "Kibana"
+  version: "4.3.1-rancher1"
+  description: "Kibana: Explore & Visualize Your Data"
+  uuid: kibana-4
+  questions:
+    - variable: "elasticsearch_source"
+      description: "Link to elasticsearch service or stack/service"
+      label: "Elasticsearch source"
+      type: "service"
+      required: true
+      default: "es/elasticsearch-clients"
+nginx-proxy:
+  metadata:
+    nginx:
+      conf:
+        servername: "kibana"
+        upstream_port: 5601 

--- a/templates/kibana/config.yml
+++ b/templates/kibana/config.yml
@@ -1,4 +1,4 @@
 name: "Kibana 4"
 description: "Visualization dashboard"
-version: "4.1.1-rancher1"
+version: "4.3.1-rancher1"
 category: "ELK"

--- a/templates/logstash/1/docker-compose.yml
+++ b/templates/logstash/1/docker-compose.yml
@@ -1,0 +1,53 @@
+redis:
+  restart: always
+  tty: true
+  image: redis:3.0.3
+  stdin_open: true
+  labels:
+    io.rancher.container.hostname_override: container_name
+logstash-indexer-config:
+  restart: always
+  image: rancher/logstash-config:v0.2.0
+  labels:
+    io.rancher.container.hostname_override: container_name
+logstash-indexer:
+  restart: always
+  tty: true
+  volumes_from:
+  - logstash-indexer-config
+  command:
+  - logstash
+  - -f
+  - /etc/logstash
+  image: logstash:2.1.1-1
+  links:
+  - redis:redis
+  external_links:
+  - ${elasticsearch_link}:elasticsearch
+  stdin_open: true
+  labels:
+    io.rancher.sidekicks: logstash-indexer-config
+    io.rancher.container.hostname_override: container_name
+logstash-collector-config:
+  restart: always
+  image: rancher/logstash-config:v0.2.0
+  labels:
+    io.rancher.container.hostname_override: container_name
+logstash-collector:
+  restart: always
+  tty: true
+  links:
+  - redis:redis
+  ports:
+  - "5000/udp"
+  volumes_from:
+  - logstash-collector-config
+  command:
+  - logstash
+  - -f
+  - /etc/logstash
+  image: logstash:2.1.1-1
+  stdin_open: true
+  labels:
+    io.rancher.sidekicks: logstash-collector-config
+    io.rancher.container.hostname_override: container_name

--- a/templates/logstash/1/rancher-compose.yml
+++ b/templates/logstash/1/rancher-compose.yml
@@ -1,0 +1,71 @@
+.catalog:
+  name: "Logstash"
+  version: "2.1.1-1-Rancher1"
+  description: "Logstash: Process Any Data, From Any Source"
+  uuid: logstash-2
+  questions:
+    - variable: "collector_inputs"
+      description: |
+        Logstash collection tier inputs. These will be added
+        directly to input { } section of logstash.conf
+      label: "Logstash inputs"
+      type: "multiline"
+      required: true
+      default: |
+        udp {
+          port => 5000
+          codec => "json"
+        }
+    - variable: "indexer_filters"
+      description: |
+        Logstash indexing tier filters. These will be added
+        directly to filter { } section of logstash.conf
+      label: "Logstash filters"
+      type: "multiline"
+      required: false
+      default: ""
+    - variable: "indexer_outputs"
+      description: |
+        Logstash indexing tier outputs. These will be added
+        directly to output { } section of logstash.conf
+      label: "Logstash outputs"
+      type: "multiline"
+      required: true
+      default: |
+        elasticsearch {
+          hosts => ["elasticsearch:9200"]
+        }
+    - variable: "elasticsearch_link"
+      description: |
+        stack/service link or external service link to elasticsearch
+        cluster.
+      label: "Elasticsearch stack/service"
+      default: "es/elasticsearch-clients"
+      required: true
+      type: "service"
+logstash-indexer:
+  metadata:
+    logstash:
+      inputs: |
+        redis {
+          host => "redis"
+          port => "6379"
+          data_type => "list"
+          key => "logstash"
+        }
+      filters: |
+        ${indexer_filters}
+      outputs: |
+        ${indexer_outputs}
+logstash-collector:
+  metadata:
+    logstash:
+      inputs: |
+        ${collector_inputs}
+      outputs: |
+        redis {
+          host => "redis"
+          port => "6379"
+          data_type => "list"
+          key => "logstash"
+        }

--- a/templates/logstash/1/rancher-compose.yml
+++ b/templates/logstash/1/rancher-compose.yml
@@ -1,6 +1,6 @@
 .catalog:
   name: "Logstash"
-  version: "2.1.1-1-Rancher1"
+  version: "2.1.1-1-rancher1"
   description: "Logstash: Process Any Data, From Any Source"
   uuid: logstash-2
   questions:

--- a/templates/logstash/config.yml
+++ b/templates/logstash/config.yml
@@ -1,5 +1,5 @@
 name: Logstash
 description: |
   Centralize data processing of all types
-version: 1.5.3-1-rancher1
+version: 2.1.1-1-rancher1
 category: ELK


### PR DESCRIPTION
# Changes from elasticsearch v1.7.3 template
## docker-compose.yml

Use new rancher elasticsearch-conf v0.5.0 docker image.
Use new rancher kopf v0.5.0 docker image.
## rancher-compose.yml

Set template version to "2.1.1-rancher1"
## config.yml

Set default template version to use to "2.1.1-rancher1"
# Changes from Logstash v1.5.3 template
## docker-compose.yml

Use logstash:2.1.1-1 image from docker hub.
## rancher-compose.yml

Set template version to "2.1.1-1-rancher1"
Change default elasticsearch output config:
- "host" is now "hosts", is an array, and the array entries follow 'address:port'.
- "port" no longer exists.
- "index" now has the default of "logstash-%{+YYYY.MM.dd}".
## config.yml

Set default template version to use to "2.1.1-1-rancher1"
# Changes from Kibana v4.1.1 template
## docker-compose.yml

Use kibana:4.3.1 image from docker hub.
## rancher-compose.yml

Set template version to "4.3.1-rancher1"
## config.yml

Set default template version to use to "4.3.1-rancher1"
