### PR TITLE
Update container and launch configuration

### DIFF
--- a/templates/jenkins-swarm/1/README.md
+++ b/templates/jenkins-swarm/1/README.md
@@ -1,0 +1,21 @@
+## Jenkins Swarm Plugin Clients
+### Experimental
+
+
+### Info:
+
+This template deploys Jenkins Swarm Clients through Rancher. These clients will come up and imediately be available for running Jenkins jobs. 
+
+### Requires
+
+Docker 1.9.1 - This image bundles in Docker 1.9.1 and bind mounts the host Docker socket. This means it will unfortunately fail on clients older then Docker 1.9.1.
+
+### Usage
+
+User: If you plan to use Jenkins Swarm plugin AND Docker you need to use `root`. If you are not going to use Docker, you can run as the `jenkins` user. The `jenkins` user does not have access ot the Docker socket.
+
+Jenkins User: If authentication is turned on, you will need to supply the username the swarm clients should login with.
+
+Jenkins Password: If authentication is turned on, you will need to supply the password the swarm clients should use.
+
+swarm executors: Number of build jobs to run on the client. The default is the number of CPUs.

--- a/templates/jenkins-swarm/1/docker-compose.yml
+++ b/templates/jenkins-swarm/1/docker-compose.yml
@@ -1,0 +1,16 @@
+swarm-clients:
+  image: "rancher/jenkins-swarm:v0.2.0"
+  user: "${user}"
+  labels:
+    io.rancher.scheduler.affinity:host_label_soft: ci=worker
+    io.rancher.container.hostname_override: container_name
+  external_links:
+    - "${jenkins_service}:jenkins-primary"
+  environment:
+    JENKINS_PASS: "${jenkins_pass}"
+    JENKINS_USER: "${jenkins_user}"
+    SWARM_EXECUTORS: "${swarm_executors}"
+  volumes:
+    - '/var/run/docker.sock:/var/run/docker.sock'
+    - '/var/jenkins_home/workspace:/var/jenkins_home/workspace'
+    - '/tmp:/tmp'

--- a/templates/jenkins-swarm/1/rancher-compose.yml
+++ b/templates/jenkins-swarm/1/rancher-compose.yml
@@ -1,0 +1,40 @@
+.catalog:
+  name: Jenkins Swarm
+  version: "2.0-rancher2"
+  description: |
+    Containers that run the slave plugin.
+  uuid: jenkins-swarm-1
+  questions:
+    - variable: user
+      label: "User to run swarm process"
+      description: |
+        If using the Host Docker, this needs to be root.
+      default: jenkins
+      required: true
+      type: enum
+      options:
+        - jenkins
+        - root
+    - variable: jenkins_user
+      label: "Jenkins username"
+      type: "string"
+      required: false
+      description: |
+        Username to authenticate to a secured Jenkins host with.
+    - variable: jenkins_pass
+      label: "Jenkins password"
+      type: "string"
+      required: false
+      description: |
+        Password to authenticate to a secured Jenkins host with.
+    - variable: swarm_executors
+      required: false
+      type: "string"
+      description: |
+        Number of executors on the swarm. Default is #cpus
+    - variable: jenkins_service
+      label: "Jenkins Server"
+      type: "service"
+      required: true
+      description: |
+        Service that is running Jenkins CI server

--- a/templates/jenkins-swarm/config.yml
+++ b/templates/jenkins-swarm/config.yml
@@ -1,5 +1,5 @@
 name: Jenkins Swarm Plugin
 description: |
   Swarm plugin to create dynamic builders
-version: "2.0-rancher1"
+version: "2.0-rancher2"
 category: Continuous Integration


### PR DESCRIPTION
Bind mount to the host in /var/jenkins_home so the workspace can be shared with
Docker build environment plugin.
Add /tmp bind mount to the host because of Docker build env plugin.
Add bundled Docker 1.9.1 binary to the image.
