### PR TITLE
Remove unused uuid field, update Galera description

### DIFF
--- a/templates/MongoDB/0/rancher-compose.yml
+++ b/templates/MongoDB/0/rancher-compose.yml
@@ -2,7 +2,6 @@
   name: "MongoDB"
   version: "3.0.0-rancher1"
   description: "MongoDB Replica Set"
-  uuid: mongodb-0
   minimum_rancher_version: v0.46.0
   questions:
     - variable: replset_name

--- a/templates/cloudflare/0/rancher-compose.yml
+++ b/templates/cloudflare/0/rancher-compose.yml
@@ -2,7 +2,6 @@
   name: "CloudFlare DNS"
   version: "v0.1.9-rancher1"
   description: "Rancher External DNS service powered by CloudFlare. Requires Rancher version 0.44.0"
-  uuid: cloudflare-0
   minimum_rancher_version: v0.44.0
   questions:
     - variable: "CLOUDFLARE_EMAIL"

--- a/templates/cloudflare/1/rancher-compose.yml
+++ b/templates/cloudflare/1/rancher-compose.yml
@@ -2,7 +2,6 @@
   name: "CloudFlare DNS"
   version: "v0.2.1-rancher1"
   description: "Rancher External DNS service powered by CloudFlare. Requires Rancher version 0.44.0"
-  uuid: cloudflare-1
   minimum_rancher_version: v0.44.0
   questions:
     - variable: "CLOUDFLARE_EMAIL"

--- a/templates/convoy-gluster/0/rancher-compose.yml
+++ b/templates/convoy-gluster/0/rancher-compose.yml
@@ -2,7 +2,6 @@
     name: "Convoy GlusterFS"
     version: "v0.1"
     description: "Convoy GlusterFS - Docker volume plugin"
-    uuid: "convoy-0"
     questions:
      - variable: "VOLUME_POOL"
        description: "Name of the GlusterFS Volume"

--- a/templates/convoy-gluster/1/rancher-compose.yml
+++ b/templates/convoy-gluster/1/rancher-compose.yml
@@ -2,7 +2,6 @@
     name: "Convoy GlusterFS"
     version: "v0.2"
     description: "Convoy GlusterFS - Docker volume plugin"
-    uuid: "convoy-gluster-1"
     questions:
      - variable: "VOLUME_POOL"
        description: "Name of the GlusterFS Volume"

--- a/templates/convoy-nfs/0/rancher-compose.yml
+++ b/templates/convoy-nfs/0/rancher-compose.yml
@@ -2,7 +2,6 @@
     name: "Convoy NFS"
     version: "v0.1"
     description: "Convoy NFS - Docker volume plugin"
-    uuid: "convoy-nfs-0"
     questions:
      - variable: "NFS_SERVER"
        description: "IP or hostname of the NFS Server"

--- a/templates/convoy-nfs/1/rancher-compose.yml
+++ b/templates/convoy-nfs/1/rancher-compose.yml
@@ -2,7 +2,6 @@
     name: "Convoy NFS"
     version: "v0.2"
     description: "Convoy NFS - Docker volume plugin"
-    uuid: "convoy-nfs-1"
     questions:
      - variable: "NFS_SERVER"
        description: "IP or hostname of the NFS Server"

--- a/templates/dnsimple/0/rancher-compose.yml
+++ b/templates/dnsimple/0/rancher-compose.yml
@@ -2,7 +2,6 @@
   name: "DNSimple DNS"
   version: "v0.1.9-rancher1"
   description: "Rancher External DNS service powered by DNSimple. Requires Rancher version 0.44.0"
-  uuid: dnsimple-0
   minimum_rancher_version: v0.44.0
   questions:
     - variable: "DNSIMPLE_EMAIL"

--- a/templates/dnsimple/1/rancher-compose.yml
+++ b/templates/dnsimple/1/rancher-compose.yml
@@ -2,7 +2,6 @@
   name: "DNSimple DNS"
   version: "v0.2.1-rancher1"
   description: "Rancher External DNS service powered by DNSimple. Requires Rancher version 0.44.0"
-  uuid: dnsimple-1
   minimum_rancher_version: v0.44.0
   questions:
     - variable: "DNSIMPLE_EMAIL"

--- a/templates/elasticsearch/0/rancher-compose.yml
+++ b/templates/elasticsearch/0/rancher-compose.yml
@@ -2,7 +2,6 @@
   name: "Elasticsearch"
   version: "1.7.1-rancher1"
   description: "Elasticsearch. You know, for search"
-  uuid: elasticsearch-0
   questions:
     - variable: cluster_name
       description: "Unique name to assign to your Elasticsearch cluster."

--- a/templates/elasticsearch/1/rancher-compose.yml
+++ b/templates/elasticsearch/1/rancher-compose.yml
@@ -2,7 +2,6 @@
   name: "Elasticsearch"
   version: "1.7.3-rancher1"
   description: "Elasticsearch. You know, for search"
-  uuid: elasticsearch-1
   questions:
     - variable: cluster_name
       description: "Unique name to assign to your Elasticsearch cluster."

--- a/templates/etcd/0/rancher-compose.yml
+++ b/templates/etcd/0/rancher-compose.yml
@@ -4,7 +4,6 @@
   description: |
     (Experimental)Distributed reliable key-value store
   minimum_rancher_version: "v0.46.0"
-  uuid: etcd-0
   questions:
     - variable: "scale"
       description: "Number of Etcd nodes"

--- a/templates/galera/0/rancher-compose.yml
+++ b/templates/galera/0/rancher-compose.yml
@@ -3,7 +3,6 @@
   version: 10.0.22-rancher1
   description: |
     Galera Cluster based on MariaDB 10.0.22
-  uuid: galeradb-0
   questions:
     - variable: "mysql_root_password"
       type: string

--- a/templates/galera/config.yml
+++ b/templates/galera/config.yml
@@ -1,5 +1,5 @@
-name: (Experimental) Galera DB 
+name: MariaDB Galera Cluster
 description: |
-    Maria GaleraDB cluster based on MariaDB 10.0.22 the Galera cluster plugin
+    (Experimental) Synchronous multi-master cluster for MariaDB
 version: 10.0.22-rancher1
 category: Database

--- a/templates/glusterfs/0/rancher-compose.yml
+++ b/templates/glusterfs/0/rancher-compose.yml
@@ -2,7 +2,6 @@
   name: "GlusterFS"
   version: "3.7.5-rancher1"
   description: "Gluster FS (3x) replicated volume"
-  uuid: glusterfs-0
   questions:
     - variable: "VOLUME_NAME"
       description: "Name to give the Gluster volume"

--- a/templates/hadoop/0/rancher-compose.yml
+++ b/templates/hadoop/0/rancher-compose.yml
@@ -2,7 +2,6 @@
   name: "Hadoop + Yarn"
   version: "2.7.1-rancher1"
   description: "Hadoop + Yarn"
-  uuid: hadoop-0
   minimum_rancher_version: v0.46.0
   questions:
     - variable: "cluster"

--- a/templates/hadoop/config.yml
+++ b/templates/hadoop/config.yml
@@ -1,5 +1,5 @@
 name: Hadoop + Yarn
 description: |
-  EXPERIMENTAL - Hadoop + Yarn Big Data Tools. (Requires 2+ nodes)
+  (Experimental - Requires 2+ hosts) Hadoop + Yarn big data tools
 version: 2.7.1-rancher1
 category: Big Data

--- a/templates/jenkins-ci/0/rancher-compose.yml
+++ b/templates/jenkins-ci/0/rancher-compose.yml
@@ -3,7 +3,6 @@
   version: 1.625.1-rancher1
   description: |
     Jenkins CI management server.
-  uuid: jenkins-ci-0
   questions:
     - variable: "plugins"
       type: "multiline"

--- a/templates/jenkins-ci/1/rancher-compose.yml
+++ b/templates/jenkins-ci/1/rancher-compose.yml
@@ -3,7 +3,6 @@
   version: 1.625.2-rancher1
   description: |
     Jenkins CI management server.
-  uuid: jenkins-ci-1
   questions:
     - variable: "plugins"
       type: "multiline"

--- a/templates/jenkins-swarm/0/rancher-compose.yml
+++ b/templates/jenkins-swarm/0/rancher-compose.yml
@@ -3,7 +3,6 @@
   version: "2.0-rancher1"
   description: |
     Containers that run the slave plugin.
-  uuid: jenkins-swarm-0
   questions:
     - variable: user
       label: "User to run swarm process"

--- a/templates/jenkins-swarm/1/rancher-compose.yml
+++ b/templates/jenkins-swarm/1/rancher-compose.yml
@@ -3,7 +3,6 @@
   version: "2.0-rancher2"
   description: |
     Containers that run the slave plugin.
-  uuid: jenkins-swarm-1
   questions:
     - variable: user
       label: "User to run swarm process"

--- a/templates/kibana/0/rancher-compose.yml
+++ b/templates/kibana/0/rancher-compose.yml
@@ -2,7 +2,6 @@
   name: "Kibana"
   version: "4.1.1-rancher1"
   description: "Kibana: Explore & Visualize Your Data"
-  uuid: kibana-0
   questions:
     - variable: "elasticsearch_source"
       description: "Link to elasticsearch service or stack/service"

--- a/templates/kubernetes/0/rancher-compose.yml
+++ b/templates/kubernetes/0/rancher-compose.yml
@@ -2,7 +2,6 @@
     name: Kubernetes
     version: v1.1.0-rancher1
     description: Manage a cluster of Linux containers as a single system to accelerate Dev and simplify Ops.
-    uuid: kubernetes-0
     questions:
         - variable: "api_server_port"
           label: "Kubernetes API port"

--- a/templates/kubernetes/config.yml
+++ b/templates/kubernetes/config.yml
@@ -1,5 +1,5 @@
 name: Kubernetes
 description: |
-  Manage a cluster of Linux containers as a single system to accelerate Dev and simplify Ops.
+  Manage a cluster of Linux containers as a single system to accelerate Dev and simplify Ops
 version: v1.1.0-rancher1
 category: Container Management

--- a/templates/logspout/0/rancher-compose.yml
+++ b/templates/logspout/0/rancher-compose.yml
@@ -3,7 +3,6 @@
   version: 0.2.0-rancher1
   description: |
     Logspout is a log router for Docker containers.
-  uuid: logspout-0
   questions:
     - variable: "route_uri"
       label: "Logspout route for logs"

--- a/templates/logstash/0/rancher-compose.yml
+++ b/templates/logstash/0/rancher-compose.yml
@@ -2,7 +2,6 @@
   name: "Logstash"
   version: "1.5.3-1-rancher1"
   description: "Logstash: Process Any Data, From Any Source"
-  uuid: logstash-0
   questions:
     - variable: "collector_inputs"
       description: |

--- a/templates/pointhq/0/rancher-compose.yml
+++ b/templates/pointhq/0/rancher-compose.yml
@@ -2,7 +2,6 @@
   name: "PointHQ DNS"
   version: "v0.2.0-rancher1"
   description: "Rancher External DNS service powered by PointHQ. Requires Rancher version 0.44.0"
-  uuid: pointhq-0
   minimum_rancher_version: v0.44.0
   questions:
     - variable: "POINTHQ_EMAIL"

--- a/templates/pointhq/1/rancher-compose.yml
+++ b/templates/pointhq/1/rancher-compose.yml
@@ -2,7 +2,6 @@
   name: "PointHQ DNS"
   version: "v0.2.1-rancher1"
   description: "Rancher External DNS service powered by PointHQ. Requires Rancher version 0.44.0"
-  uuid: pointhq-1
   minimum_rancher_version: v0.44.0
   questions:
     - variable: "POINTHQ_EMAIL"

--- a/templates/route53/0/rancher-compose.yml
+++ b/templates/route53/0/rancher-compose.yml
@@ -2,7 +2,6 @@
   name: "Route53 DNS"
   version: "v0.1.5-rancher1"
   description: "Rancher External DNS service powered by Amazon Route53. Requires Rancher version 0.44.0"
-  uuid: route53-0
   questions:
     - variable: "AWS_ACCESS_KEY"
       label: "AWS access key"

--- a/templates/route53/1/rancher-compose.yml
+++ b/templates/route53/1/rancher-compose.yml
@@ -2,7 +2,6 @@
   name: "Route53 DNS"
   version: "v0.1.6-rancher1"
   description: "Rancher External DNS service powered by Amazon Route53. Requires Rancher version 0.44.0"
-  uuid: route53-1
   minimum_rancher_version: v0.44.0
   questions:
     - variable: "AWS_ACCESS_KEY"

--- a/templates/route53/2/rancher-compose.yml
+++ b/templates/route53/2/rancher-compose.yml
@@ -2,7 +2,6 @@
   name: "Route53 DNS"
   version: "v0.1.7-rancher1"
   description: "Rancher External DNS service powered by Amazon Route53. Requires Rancher version 0.44.0"
-  uuid: route53-2
   minimum_rancher_version: v0.44.0
   questions:
     - variable: "AWS_ACCESS_KEY"

--- a/templates/route53/3/rancher-compose.yml
+++ b/templates/route53/3/rancher-compose.yml
@@ -2,7 +2,6 @@
   name: "Route53 DNS"
   version: "v0.2.1-rancher1"
   description: "Rancher External DNS service powered by Amazon Route53. Requires Rancher version 0.44.0"
-  uuid: route53-3
   minimum_rancher_version: v0.44.0
   questions:
     - variable: "AWS_ACCESS_KEY"

--- a/templates/sysdig-cloud/0/rancher-compose.yml
+++ b/templates/sysdig-cloud/0/rancher-compose.yml
@@ -2,7 +2,6 @@
   name: "Sysdig Cloud"
   version: "v0"
   description: "Container-Native Application and Infrastructure Monitoring"
-  uuid: sysdig-cloud-0
   questions:
     - variable: "SDC_ACCESS_KEY"
       label: "Sysdig Cloud access key"

--- a/templates/sysdig/0/rancher-compose.yml
+++ b/templates/sysdig/0/rancher-compose.yml
@@ -2,7 +2,6 @@
   name: "Sysdig"
   version: "v0"
   description: "Container-Native System Visibility and Troubleshooting"
-  uuid: sysdig-0
   questions:
     - variable: "VERSION"
       label: "Sysdig version"

--- a/templates/weavescope/0/rancher-compose.yml
+++ b/templates/weavescope/0/rancher-compose.yml
@@ -2,4 +2,3 @@
   name: weavescope
   version: 0.11.1
   description: "Monitoring, visualisation and management for Docker"
-  uuid: weavescope-0

--- a/templates/zookeeper/0/rancher-compose.yml
+++ b/templates/zookeeper/0/rancher-compose.yml
@@ -4,7 +4,6 @@
   description: |
     (Experimental) Apache Zookeeper cluster.
   minimum_rancher_version: v0.46.0
-  uuid: zookeeper-0
   questions:
     - variable: "scale"
       description: "Number of Zookeeper nodes. Note: it should be an odd number"


### PR DESCRIPTION
UUID is not actually used for anything anymore since (https://github.com/rancher/rancher-catalog-service/commit/372f85b493030551e6d65b37dab01f6604c2e101) and is generally confusing.  @deniseschannon it should be removed from the docs too once merged
