### PR TITLE
Reconfigured for healthcheck

### DIFF
--- a/templates/drone/1/README.md
+++ b/templates/drone/1/README.md
@@ -1,0 +1,17 @@
+# Drone
+
+### Info:
+
+This template creates an instance of Drone CI server 0.4.
+
+### Usage:
+
+Select the Drone template from the catalog. Provide the following information:
+
+1. Database driver
+2. Database configuration: this will look like either a path `/var/lib/drone/sqlite3` or a connection string `<user>:<password>@tcp(database:<port>)<database>?parseTime=true`
+The name will always be database.
+3. Remote repository store. (Ie. GitHub)
+4. Remote repository store configuration.
+
+See [Drone documentation](http://readme.drone.io/setup/overview/) for complete information.

--- a/templates/drone/1/docker-compose.yml
+++ b/templates/drone/1/docker-compose.yml
@@ -1,0 +1,45 @@
+drone-lb:
+  ports:
+  - ${public_port}:8000
+  tty: true
+  image: rancher/load-balancer-service
+  links:
+  - drone-server:drone-server
+  stdin_open: true
+
+drone-healthcheck:
+  image: rancher/drone-config:v0.1.0
+  net: 'container:drone-server'
+  volumes_from:
+    - drone-data-volume
+  entrypoint: /giddyup health
+
+drone-server:
+  image: rancher/drone-config:v0.1.0
+  volumes_from:
+    - drone-data-volume
+  labels: 
+    io.rancher.sidekicks: drone-data-volume,drone-daemon,drone-healthcheck
+  external_links:
+    - ${database_service}:database
+
+drone-daemon:
+  image: rancher/drone:0.4
+  net: 'container:drone-server'
+  volumes:
+    - /var/run/docker.sock:/var/run/docker.sock
+  volumes_from:
+    - drone-data-volume
+  entrypoint: /opt/rancher/rancher_entry.sh
+
+## Do not change below. Could cause data loss in upgrade.
+drone-data-volume:
+  image: busybox
+  net: none
+  command: /bin/true
+  labels:
+    io.rancher.container.start_once: 'true'
+  volumes:
+    - /var/lib/drone
+    - /etc/drone
+    - /opt/rancher

--- a/templates/drone/1/rancher-compose.yml
+++ b/templates/drone/1/rancher-compose.yml
@@ -1,0 +1,73 @@
+.catalog:
+  name: Drone
+  version: 0.4-rancher2
+  description: |
+    Drone CI Server
+  questions:
+    - variable: "remote_driver"
+      type: "enum"
+      required: true
+      label: "Remote Driver"
+      description: "Remote Git and Auth scheme"
+      options:
+        - github
+        - bitbucket
+        - gitlab
+        - gogs
+    - variable: "remote_config"
+      type: "password"
+      required: true
+      label: "Remote Config"
+      description: "Must be the full connection string. see http://readme.drone.io/setup/overview/ for more info"
+    - variable: "public_port"
+      type: "int"
+      required: true
+      label: "Public Port"
+      description: "Port that the load balancer will listen on. Must be accessible to remote driver for webhooks"
+    - variable: "database_driver"
+      type: "enum"
+      label: "Database Driver"
+      description: "Database backend to use."
+      required: true
+      default: "sqlite3"
+      options:
+        - sqlite3
+        - postgres
+        - mysql
+    - variable: "database_config"
+      label: "Database Config"
+      type: "password"
+      required: true
+      description: "Must be full db string. The hostname for the DB will be 'database'. See http://readme.drone.io/setup/overview/ for more info"
+    - variable: "database_service"
+      type: "service"
+      label: "Database Service"
+      description: "Service to link to for database. For instance if using the default Rancher Galera cluster select galera/galera-lb."
+      default: "drone-server"
+drone-lb:
+  scale: 1
+  load_balancer_config:
+    haproxy_config: {}
+  health_check:
+    port: 42
+    interval: 2000
+    unhealthy_threshold: 3
+    healthy_threshold: 2
+    response_timeout: 2000
+drone-server:
+  scale: 1
+  metadata:
+    remote_driver: ${remote_driver}
+    remote_config: "${remote_config}"
+    database_driver: ${database_driver}
+    database_config: "${database_config}"
+    http_proxy_on: "false"
+    debug: "true"
+  health_check:
+    port: 1620
+    interval: 2000
+    unhealthy_threshold: 3
+    strategy: recreate
+    request_line: GET /ping HTTP/1.0
+    healthy_threshold: 2
+    response_timeout: 2000

--- a/templates/drone/config.yml
+++ b/templates/drone/config.yml
@@ -1,5 +1,5 @@
 name: Drone
 description: |
     Drone CI Server
-version: 0.4-rancher1
+version: 0.4-rancher2
 category: Continuous Integration


### PR DESCRIPTION
This configuration exposes the healthcheck to Rancher. This endpoint
could be exposed to an external load balancer or something if needed.
