### PR TITLE
 New template for route53 

### DIFF
--- a/templates/route53/4/docker-compose.yml
+++ b/templates/route53/4/docker-compose.yml
@@ -1,0 +1,13 @@
+route53:
+  image: rancher/external-dns:v0.3.0
+  expose: 
+   - 1000
+  environment:
+    AWS_ACCESS_KEY: ${AWS_ACCESS_KEY}
+    AWS_SECRET_KEY: ${AWS_SECRET_KEY}
+    AWS_REGION: ${AWS_REGION}
+    ROOT_DOMAIN: ${ROOT_DOMAIN}
+    TTL: ${TTL}
+  labels:
+    io.rancher.container.create_agent: "true"
+    io.rancher.container.agent.role: "external-dns"

--- a/templates/route53/4/rancher-compose.yml
+++ b/templates/route53/4/rancher-compose.yml
@@ -1,0 +1,42 @@
+.catalog:
+  name: "Route53 DNS"
+  version: "v0.3.0-rancher1"
+  description: "Rancher External DNS service powered by Amazon Route53. Requires Rancher version 0.44.0"
+  minimum_rancher_version: v0.44.0
+  questions:
+    - variable: "AWS_ACCESS_KEY"
+      label: "AWS access key"
+      description: "Access key to your AWS account"
+      type: "string"
+      required: true
+    - variable: "AWS_SECRET_KEY"
+      label: "AWS secret key"
+      description: "Secret key to your AWS account"
+      type: "string"
+      required: true
+    - variable: "AWS_REGION"
+      label: "AWS region"
+      description: "AWS region name"
+      type: "string"
+      default: "us-west-2"
+      required: true
+    - variable: "ROOT_DOMAIN"
+      label: "Hosted zone"
+      description: "Route53 hosted zone name (zone has to be pre-created). DNS entries will be created for <service>.<stack>.<environment>.<hosted zone>"
+      type: "string"
+      required: true
+    - variable: "TTL"
+      label: "TTL"
+      description: "The resource record cache time to live (TTL), in seconds"
+      type: "int"
+      default: 299 
+      required: false
+
+route53:
+  health_check:
+    port: 1000
+    interval: 2000
+    unhealthy_threshold: 3
+    request_line: GET / HTTP/1.0
+    healthy_threshold: 2
+    response_timeout: 2000


### PR DESCRIPTION
The template defaults the TTL value to 299(so that rancher added route53 records can be identified) and this template points to new external-dns release v0.3.0

I have tested this template and verified the records got created on AWS route53 hostedzone.
https://github.com/rancher/rancher/issues/3716
