### PR TITLE
Template Route53 v0.4.2

### DIFF
--- a/templates/route53/7/docker-compose.yml
+++ b/templates/route53/7/docker-compose.yml
@@ -1,0 +1,14 @@
+route53:
+  image: rancher/external-dns:v0.4.2
+  expose: 
+   - 1000
+  environment:
+    AWS_ACCESS_KEY: ${AWS_ACCESS_KEY}
+    AWS_SECRET_KEY: ${AWS_SECRET_KEY}
+    AWS_REGION: ${AWS_REGION}
+    ROOT_DOMAIN: ${ROOT_DOMAIN}
+    ROUTE53_ZONE_ID: ${ROUTE53_ZONE_ID}
+    TTL: ${TTL}
+  labels:
+    io.rancher.container.create_agent: "true"
+    io.rancher.container.agent.role: "external-dns"

--- a/templates/route53/7/rancher-compose.yml
+++ b/templates/route53/7/rancher-compose.yml
@@ -1,0 +1,47 @@
+.catalog:
+  name: "Route53 DNS"
+  version: "v0.4.2-rancher1"
+  description: "Rancher External DNS service powered by Amazon Route53. Requires Rancher version 0.44.0"
+  minimum_rancher_version: v0.44.0
+  questions:
+    - variable: "AWS_ACCESS_KEY"
+      label: "AWS Access Key ID"
+      description: "Access key to your AWS account"
+      type: "string"
+      required: true
+    - variable: "AWS_SECRET_KEY"
+      label: "AWS Secret Access Key"
+      description: "Secret key to your AWS account"
+      type: "string"
+      required: true
+    - variable: "AWS_REGION"
+      label: "AWS Region"
+      description: "AWS region name"
+      type: "string"
+      default: "us-west-2"
+      required: true
+    - variable: "TTL"
+      label: "TTL"
+      description: "The resource record cache time to live (TTL), in seconds"
+      type: "int"
+      default: 60
+      required: false
+    - variable: "ROOT_DOMAIN"
+      label: "Hosted Zone Name"
+      description: "Route53 hosted zone name (zone has to be pre-created). DNS entries will be created for <service>.<stack>.<environment>.<hosted zone>"
+      type: "string"
+      required: true
+    - variable: "ROUTE53_ZONE_ID"
+      label: "Hosted Zone ID"
+      description: "If there are multiple zones with the same name, then additionally specify the ID of the zone to use."
+      type: "string"
+      required: false
+
+route53:
+  health_check:
+    port: 1000
+    interval: 30000
+    unhealthy_threshold: 2
+    request_line: GET / HTTP/1.0
+    healthy_threshold: 1
+    response_timeout: 5000

--- a/templates/route53/7/rancher-compose.yml
+++ b/templates/route53/7/rancher-compose.yml
@@ -40,8 +40,8 @@
 route53:
   health_check:
     port: 1000
-    interval: 30000
+    interval: 15000
     unhealthy_threshold: 2
     request_line: GET / HTTP/1.0
-    healthy_threshold: 1
+    healthy_threshold: 2
     response_timeout: 5000

--- a/templates/route53/README.md
+++ b/templates/route53/README.md
@@ -1,0 +1,35 @@
+## Route53 DNS
+
+#### Rancher External DNS service powered by Amazon Route53
+
+This IAM policy describes the minimum permissions required for this service. Replace `<HOSTED_ZONE_ID>` with the ID of the hosted zone.
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "route53:GetChange",
+                "route53:GetHostedZone",
+                "route53:GetHostedZoneCount",
+                "route53:ListHostedZonesByName",
+                "route53:ListResourceRecordSets"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "route53:ChangeResourceRecordSets"
+            ],
+            "Resource": [
+                "arn:aws:route53:::hostedzone/<HOSTED_ZONE_ID>"
+            ]
+        }
+    ]
+}
+``` 

--- a/templates/route53/config.yml
+++ b/templates/route53/config.yml
@@ -1,5 +1,5 @@
 name: Route53 DNS
 description: |
   Rancher External DNS service powered by Amazon Route53
-version: v0.4.1-rancher1
+version: v0.4.2-rancher1
 category: Rancher Services


### PR DESCRIPTION
Do not merge - depends on rancher/external-dns:v0.4.2
- Adds README describing required AWS IAM policy
- Raises health check interval time to yield lower constant API request rate
- Lowers default TTL to 60 sec (so clients respond quicker to record changes)
