### PR TITLE
Uncross the streams

### DIFF
--- a/templates/k8s/8/docker-compose.yml
+++ b/templates/k8s/8/docker-compose.yml
@@ -1,0 +1,148 @@
+kubelet:
+    labels:
+        io.rancher.container.dns: "true"
+        io.rancher.container.create_agent: "true"
+        io.rancher.container.agent.role: environmentAdmin
+        io.rancher.scheduler.global: "true"
+    command:
+        - kubelet
+        - --kubeconfig=/etc/kubernetes/ssl/kubeconfig
+        - --api_servers=https://kubernetes:6443
+        - --allow-privileged=true
+        - --register-node=true
+        - --cloud-provider=rancher
+        - --healthz-bind-address=0.0.0.0
+        - --cluster-dns=169.254.169.250
+        - --cluster-domain=cluster.local
+    image: rancher/k8s:v1.2.4-rancher9
+    volumes:
+        - /var/run/docker.sock:/var/run/docker.sock
+        - /var/run:/host/var/run
+        - /var/lib/docker:/var/lib/docker
+        - /dev:/host/dev
+    net: host
+    pid: host
+    ipc: host
+    privileged: true
+    links:
+        - kubernetes
+
+proxy:
+    labels:
+        io.rancher.container.dns: "true"
+        io.rancher.scheduler.global: "true"
+    command:
+        - kube-proxy
+        - --master=http://master
+        - --v=2
+        - --healthz-bind-address=0.0.0.0
+        - --proxy-mode=userspace
+    image: rancher/k8s:v1.2.4-rancher9
+    privileged: true
+    net: host
+    links:
+        - kubernetes:master
+
+etcd:
+  image: rancher/etcd:v2.3.7-6
+  labels:
+    io.rancher.scheduler.affinity:container_label_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
+    io.rancher.sidekicks: data
+  environment:
+    ETCD_DATA_DIR: /data
+    RANCHER_DEBUG: 'true'
+  links:
+  - data
+  volumes_from:
+  - data
+
+data:
+  image: busybox
+  entrypoint: /bin/true
+  net: none
+  volumes:
+  - /data
+  labels:
+    io.rancher.container.start_once: 'true'
+
+kubernetes:
+    labels:
+        io.rancher.container.create_agent: "true"
+        io.rancher.container.agent.role: environmentAdmin
+    command: 
+        - kube-apiserver
+        - --service-cluster-ip-range=10.43.0.0/16
+        - --etcd-servers=http://etcd:2379
+        - --insecure-bind-address=0.0.0.0
+        - --insecure-port=80
+        - --cloud-provider=rancher
+        - --allow_privileged=true
+        - --admission-control=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ResourceQuota,ServiceAccount
+        - --client-ca-file=/etc/kubernetes/ssl/ca.pem
+        - --tls-cert-file=/etc/kubernetes/ssl/cert.pem
+        - --tls-private-key-file=/etc/kubernetes/ssl/key.pem
+    image: rancher/k8s:v1.2.4-rancher9
+    links:
+        - etcd
+
+kubectld:
+    labels:
+        io.rancher.k8s.kubectld: "true"
+    environment:
+        SERVER: http://master
+        LISTEN: ":8091"
+    image: rancher/kubectld:v0.2.1
+    links:
+        - kubernetes:master
+
+scheduler:
+    command:
+        - kube-scheduler
+        - --master=http://master
+        - --address=0.0.0.0
+    image: rancher/k8s:v1.2.4-rancher9
+    links:
+        - kubernetes:master
+
+controller-manager:
+    command:
+        - kube-controller-manager
+        - --master=https://kubernetes:6443
+        - --cloud-provider=rancher
+        - --address=0.0.0.0
+        - --kubeconfig=/etc/kubernetes/ssl/kubeconfig
+        - --root-ca-file=/etc/kubernetes/ssl/ca.pem
+        - --service-account-private-key-file=/etc/kubernetes/ssl/key.pem
+    image: rancher/k8s:v1.2.4-rancher9
+    labels:
+        io.rancher.container.create_agent: "true"
+        io.rancher.container.agent.role: environmentAdmin
+    links:
+        - kubernetes
+
+rancher-kubernetes-agent:
+    labels:
+        io.rancher.container.create_agent: "true"
+        io.rancher.container.agent_service.labels_provider: "true"
+    environment:
+        KUBERNETES_URL: http://master
+    image: rancher/kubernetes-agent:v0.2.1
+    privileged: true
+    volumes:
+        - /var/run/docker.sock:/var/run/docker.sock
+    links:
+        - kubernetes:master
+
+rancher-ingress-controller:
+    image: rancher/ingress-controller:v0.1.3
+    labels:
+        io.rancher.container.create_agent: "true"
+        io.rancher.container.agent.role: environment
+    environment:
+        KUBERNETES_URL: http://master
+    command:
+        - ingress-controller
+        - --lb-controller=kubernetes
+        - --lb-provider=rancher
+    links:
+        - kubernetes:master

--- a/templates/k8s/8/rancher-compose.yml
+++ b/templates/k8s/8/rancher-compose.yml
@@ -1,0 +1,84 @@
+.catalog:
+  name: Kubernetes
+  version: v1.2.4-rancher9
+  description: Rancher Kubernetes service
+  minimum_rancher_version: v1.1.1
+
+kubernetes:
+    metadata:
+        sans:
+        - "IP:10.43.0.1"
+    health_check:
+        request_line: GET /healthz HTTP/1.0
+        port: 80
+        interval: 2000
+        response_timeout: 2000
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+    retain_ip: true
+
+etcd:
+    retain_ip: true
+    scale_policy:
+        increment: 1
+        max: 3
+        min: 1
+    metadata:
+        scale_policy:
+            min: 1
+    health_check:
+        port: 2378
+        request_line: GET /health HTTP/1.0
+        interval: 5000
+        response_timeout: 3000
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+        recreate_on_quorum_strategy_config:
+            quorum: 2
+        strategy: recreateOnQuorum
+
+rancher-kubernetes-agent:
+    health_check:
+        request_line: GET /healthcheck HTTP/1.0
+        port: 10240
+        interval: 2000
+        response_timeout: 2000
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+
+scheduler:
+    health_check:
+        request_line: GET /healthz HTTP/1.0
+        port: 10251
+        interval: 2000
+        response_timeout: 2000
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+
+controller-manager:
+    health_check:
+        request_line: GET /healthz HTTP/1.0
+        port: 10252
+        interval: 2000
+        response_timeout: 2000
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+
+kubectld:
+    health_check:
+        port: 8091
+        interval: 2000
+        response_timeout: 2000
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+
+
+rancher-ingress-controller:
+    health_check:
+        request_line: GET /healthz HTTP/1.0
+        port: 10241
+        interval: 2000
+        response_timeout: 2000
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+


### PR DESCRIPTION
- Add a `k8s/8` that is the same as `kubernetes/7`, so the UI can migrate the template name correctly by changing the number (sigh).
