### PR TITLE
smart(?)er wait for listening catalog service

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -21,8 +21,18 @@ fi
 
 pushd /scratch/integration
 
-# Start rancher-catalog-service and wait for it to start.
 /usr/bin/rancher-catalog-service -catalogUrl ../ -refreshInterval 7200 > /dev/null 2>&1 &
-sleep 10
+
+# hang out until the service is up and listening on tcp/8088
+while true; do
+    echo 'Waiting for Rancher Catalog service to become available on localhost:8088...'
+    set +e ; curl -s --connect-timeout 2 http://localhost:8088
+    if [ "0" == "$?" ]; then
+      echo 'Succesful connection to Catalog Service on localhost:8088.'
+      set -e
+      break
+    fi
+done
+
 tox -e flake8,py27
 popd


### PR DESCRIPTION
We were getting test flakes in CI because the static wait for start of Rancher Catalog service was expiring without service start. Make the wait check for listening tcp/8088 as a reasonable predicate for working Catalog service.

@LLParse @cloudnautique
