### PR TITLE
rancher/scheduler:v0.4.0

### DIFF
--- a/infra-templates/scheduler/0/docker-compose.yml
+++ b/infra-templates/scheduler/0/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   scheduler:
-    image: rancher/scheduler:v0.3.0
+    image: rancher/scheduler:v0.4.0
     command: scheduler
     labels:
         io.rancher.container.create_agent: "true"


### PR DESCRIPTION
Partially addresses https://github.com/rancher/rancher/issues/6660
by fixing a bug where the initial usage count when you first add a host could be inaccurate.
Also, improves logging to make it more clear what the scheduler is doing.