### PR TITLE
Allow specifying a specific subnet range for the managed IPSEC network.

### DIFF
--- a/infra-templates/ipsec/1/docker-compose.yml
+++ b/infra-templates/ipsec/1/docker-compose.yml
@@ -1,0 +1,37 @@
+version: '2'
+services:
+  ipsec:
+    cap_add:
+    - NET_ADMIN
+    image: rancher/net:v0.7.5
+    network_mode: ipsec
+    ports:
+    - 500:500/udp
+    - 4500:4500/udp
+    # Force cni-driver to start first
+    volumes_from:
+    - cni-driver
+    labels:
+      io.rancher.sidekicks: cni-driver
+      io.rancher.scheduler.global: 'true'
+      io.rancher.container.create_agent: 'true'
+      io.rancher.container.agent_service.ipsec: 'true'
+    logging:
+      driver: json-file
+      options:
+        max-size: 25m
+        max-file: '2'
+  cni-driver:
+    privileged: true
+    image: rancher/net:v0.7.5
+    command: sh -c "touch /var/log/rancher-ipam.log && exec tail ---disable-inotify -F /var/log/rancher-ipam.log"
+    network_mode: host
+    pid: host
+    labels:
+      io.rancher.network.cni.binary: 'rancher-bridge'
+      io.rancher.container.dns: 'true'
+    logging:
+      driver: json-file
+      options:
+        max-size: 25m
+        max-file: '2'

--- a/infra-templates/ipsec/1/rancher-compose.yml
+++ b/infra-templates/ipsec/1/rancher-compose.yml
@@ -1,0 +1,38 @@
+.catalog:
+  name: "Rancher IPsec"
+  version: "0.0.2"
+  questions:
+    - variable: "SUBNET"
+      label: "Subnet"
+      description: "The subnet to use for the managed IPSEC network."
+      type: "string"
+      default: '10.42.0.0/16'
+      required: false
+
+ipsec:
+  network_driver:
+    name: Rancher IPsec
+    default_network:
+      name: ipsec
+      host_ports: true
+      subnets:
+      - network_address: ${SUBNET}
+      dns:
+      - 169.254.169.250
+      dns_search:
+      - rancher.internal
+    cni_config:
+      '10-rancher.conf':
+        name: rancher-cni-network
+        type: rancher-bridge
+        bridge: docker0
+        bridgeSubnet: ${SUBNET}
+        isDefaultGateway: true
+        hostNat: true
+        hairpinMode: true
+        linkMTUOverhead: 98
+        ipam:
+          type: rancher-cni-ipam
+          logToFile: /var/log/rancher-ipam.log
+          routes:
+          - dst: 169.254.169.250/32

--- a/infra-templates/ipsec/config.yml
+++ b/infra-templates/ipsec/config.yml
@@ -1,5 +1,5 @@
 name: Rancher IPsec
-version: 0.0.1
+version: 0.0.2
 category: Networking
 labels:
   io.rancher.certified: rancher


### PR DESCRIPTION
We have a conflict internally with the default managed network subnet and this seems like the nicest way to solve the problem. :)

Also if this gets merged this FAQ should be updated as well. http://docs.rancher.com/rancher/v1.2/en/faqs/troubleshooting/#the-subnet-used-by-rancher-is-already-used-in-my-network-and-prohibiting-the-managed-network-how-do-i-change-the-subnet