### PR TITLE
Use KubeDNS as the DNS service for Kubernetes

### DIFF
--- a/infra-templates/k8s/13/README.md
+++ b/infra-templates/k8s/13/README.md
@@ -1,0 +1,27 @@
+## Kubernetes 1.4
+
+### KubeDNS
+
+KubeDNS is enabled for name resolution as described in the [Kubernetes DNS docs](http://kubernetes.io/docs/admin/dns/). The DNS service IP address is `10.43.0.10`.
+
+### Backup Configuration
+
+Backups are enabled/disabled via the `Enable Backups` radio buttons.
+
+The backup period durations must be a sequence of decimal numbers, each with optional fraction and a unit suffix, such as `300ms`, `1.5h` or `2h45m`. Valid time units are `ns`, `us` or `µs`, `ms`, `s`, `m` and `h`.
+
+The `Backup Creation Period` duration indicates at what rate backups should be created. It is not recommended to create backups more often than `30s`.
+
+The `Backup Retention Period` duration indicates at what rate historical backups should be deleted. Backups outside of the retention period are expired after the next successful backup.
+
+The maximum number of backups stored on disk at any given moment follows the equation `ceiling(retention period / creation period)`. For example, `5m` creation period with `4h` retention period would store at most `ceiling(4h / 5m)` backups or `48` backups. A conservative estimate for backup size is `50MB`, so the attached network storage should have at least `2.4GB` free space. Backup sizes will vary depending on usage.
+
+If backups are disabled, the values for `Backup Creation Period` and `Backup Retention Period` are ignored.
+
+### Further Reading
+
+See [the wiki](https://github.com/rancher/rancher/wiki/Kubernetes-Management#deployment-types) for further information regarding usage of this template.
+
+### Upgrading to this Version: WARNING
+
+If you are upgrading from a previous version, rollback is not supported.

--- a/infra-templates/k8s/13/docker-compose.yml
+++ b/infra-templates/k8s/13/docker-compose.yml
@@ -1,0 +1,192 @@
+kubelet:
+    labels:
+        io.rancher.container.dns: "true"
+        io.rancher.container.create_agent: "true"
+        io.rancher.container.agent.role: environmentAdmin
+        io.rancher.scheduler.global: "true"
+        io.rancher.scheduler.affinity:host_label_ne: nopods=true
+    command:
+        - kubelet
+        - --kubeconfig=/etc/kubernetes/ssl/kubeconfig
+        - --api_servers=https://kubernetes.kubernetes.rancher.internal:6443
+        - --allow-privileged=true
+        - --register-node=true
+        - --cloud-provider=${CLOUD_PROVIDER}
+        - --healthz-bind-address=0.0.0.0
+        - --cluster-dns=10.43.0.10
+        - --cluster-domain=cluster.local
+        - --network-plugin=cni
+        - --network-plugin-dir=/etc/cni/managed.d
+    image: rancher/k8s:v1.4.6-rancher2-1
+    volumes:
+        - /run:/run
+        - /var/run:/var/run
+        - /var/lib/docker:/var/lib/docker
+        - /var/lib/kubelet:/var/lib/kubelet:shared
+        - rancher-cni-driver:/etc/cni:ro
+        - rancher-cni-driver:/opt/cni:ro
+        - /dev:/host/dev
+    net: host
+    pid: host
+    ipc: host
+    privileged: true
+    links:
+        - kubernetes
+
+proxy:
+    labels:
+        io.rancher.container.dns: "true"
+        io.rancher.scheduler.global: "true"
+        io.rancher.scheduler.affinity:host_label_ne: nopods=true
+    command:
+        - kube-proxy
+        - --master=http://kubernetes.kubernetes.rancher.internal
+        - --v=2
+        - --healthz-bind-address=0.0.0.0
+    image: rancher/k8s:v1.4.6-rancher2-1
+    privileged: true
+    net: host
+    links:
+        - kubernetes
+
+etcd:
+    image: rancher/etcd:v2.3.7-11
+    labels:
+        io.rancher.scheduler.affinity:host_label_soft: etcd=true
+        io.rancher.scheduler.affinity:container_label_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
+        io.rancher.sidekicks: data
+    environment:
+        RANCHER_DEBUG: 'true'
+        EMBEDDED_BACKUPS: '${EMBEDDED_BACKUPS}'
+        BACKUP_PERIOD: '${BACKUP_PERIOD}'
+        BACKUP_RETENTION: '${BACKUP_RETENTION}'
+    volumes:
+    - etcd:/pdata
+    - /var/etcd/backups:/data-backup
+    volumes_from:
+    - data
+
+data:
+    image: busybox
+    entrypoint: /bin/true
+    net: none
+    volumes:
+    - /data
+    labels:
+        io.rancher.container.start_once: 'true'
+
+kubernetes:
+    labels:
+        io.rancher.scheduler.affinity:host_label_soft: orchestration=true
+        io.rancher.container.create_agent: "true"
+        io.rancher.container.agent.role: environmentAdmin
+        io.rancher.sidekicks: kube-hostname-updater
+    command: 
+        - kube-apiserver
+        - --service-cluster-ip-range=10.43.0.0/16
+        - --etcd-servers=http://etcd.kubernetes.rancher.internal:2379
+        - --insecure-bind-address=0.0.0.0
+        - --insecure-port=80
+        - --cloud-provider=${CLOUD_PROVIDER}
+        - --allow_privileged=true
+        - --admission-control=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ResourceQuota,ServiceAccount
+        - --client-ca-file=/etc/kubernetes/ssl/ca.pem
+        - --tls-cert-file=/etc/kubernetes/ssl/cert.pem
+        - --tls-private-key-file=/etc/kubernetes/ssl/key.pem
+        - --runtime-config=batch/v2alpha1
+    environment:
+        KUBERNETES_URL: https://kubernetes.kubernetes.rancher.internal:6443
+    image: rancher/k8s:v1.4.6-rancher2-1
+    links:
+        - etcd
+
+kube-hostname-updater:
+    net: container:kubernetes
+    command:
+        - etc-host-updater
+    image: rancher/etc-host-updater:v0.0.2
+    links:
+        - kubernetes
+
+kubectld:
+    labels:
+        io.rancher.scheduler.affinity:host_label_soft: orchestration=true
+        io.rancher.k8s.kubectld: "true"
+        io.rancher.container.create_agent: "true"
+        io.rancher.container.agent_service.kubernetes_stack: "true"
+    environment:
+        SERVER: http://kubernetes.kubernetes.rancher.internal
+        LISTEN: ":8091"
+    image: rancher/kubectld:v0.4.0
+    links:
+        - kubernetes
+
+scheduler:
+    command:
+        - kube-scheduler
+        - --master=http://kubernetes.kubernetes.rancher.internal
+        - --address=0.0.0.0
+    image: rancher/k8s:v1.4.6-rancher2-1
+    labels:
+        io.rancher.scheduler.affinity:host_label_soft: orchestration=true
+    links:
+        - kubernetes
+
+controller-manager:
+    command:
+        - kube-controller-manager
+        - --master=https://kubernetes.kubernetes.rancher.internal:6443
+        - --cloud-provider=${CLOUD_PROVIDER}
+        - --address=0.0.0.0
+        - --kubeconfig=/etc/kubernetes/ssl/kubeconfig
+        - --root-ca-file=/etc/kubernetes/ssl/ca.pem
+        - --service-account-private-key-file=/etc/kubernetes/ssl/key.pem
+    image: rancher/k8s:v1.4.6-rancher2-1
+    labels:
+        io.rancher.scheduler.affinity:host_label_soft: orchestration=true
+        io.rancher.container.create_agent: "true"
+        io.rancher.container.agent.role: environmentAdmin
+    links:
+        - kubernetes
+
+rancher-kubernetes-agent:
+    labels:
+        io.rancher.scheduler.affinity:host_label_soft: orchestration=true
+        io.rancher.container.create_agent: "true"
+        io.rancher.container.agent_service.labels_provider: "true"
+    environment:
+        KUBERNETES_URL: http://kubernetes.kubernetes.rancher.internal
+    image: rancher/kubernetes-agent:v0.3.5
+    privileged: true
+    volumes:
+        - /var/run/docker.sock:/var/run/docker.sock
+    links:
+        - kubernetes
+
+rancher-ingress-controller:
+    image: rancher/lb-service-rancher:v0.4.0
+    labels:
+        io.rancher.scheduler.affinity:host_label_soft: orchestration=true
+        io.rancher.container.create_agent: "true"
+        io.rancher.container.agent.role: environment
+    environment:
+        KUBERNETES_URL: http://kubernetes.kubernetes.rancher.internal
+    command:
+        - lb-controller
+        - --controller=kubernetes
+        - --provider=rancher
+    links:
+        - kubernetes
+
+addon-starter:
+    image: rancher/k8s:v1.4.6-rancher2-1
+    labels:
+        io.rancher.container.create_agent: 'true'
+        io.rancher.container.start_once: 'true'
+        io.rancher.container.agent.role: environmentAdmin
+    environment:
+        KUBERNETES_URL: https://kubernetes.kubernetes.rancher.internal:6443
+    command:
+        - addons-update.sh
+    links:
+        - kubernetes

--- a/infra-templates/k8s/13/rancher-compose.yml
+++ b/infra-templates/k8s/13/rancher-compose.yml
@@ -1,0 +1,108 @@
+.catalog:
+  name: Kubernetes
+  version: v1.4.6-rancher2-1
+  description: Rancher Kubernetes service
+  minimum_rancher_version: v1.3.0
+  questions:
+  - variable: EMBEDDED_BACKUPS
+    label: Enable Backups
+    description: "Periodically backup state to /var/etcd/backups. Mount network storage here on all hosts before continuing"
+    required: true
+    default: true
+    type: boolean
+  - variable: BACKUP_PERIOD
+    label: Backup Creation Period
+    description: Create a backup after this amount of time passes. Must conform to duration format
+    required: true
+    default: 15m0s
+    type: string
+  - variable: BACKUP_RETENTION
+    label: Backup Retention Period
+    description: Expire a backup after this amount of time passes. Must conform to duration format
+    required: true
+    default: 24h
+    type: string
+  - variable: CLOUD_PROVIDER
+    label: Cloud Provider
+    description: The cloud provider on which Kubernetes is running
+    required: true
+    default: rancher
+    type: enum
+    options:
+     - rancher
+     - aws
+
+kubernetes:
+    metadata:
+        sans:
+        - "IP:10.43.0.1"
+    health_check:
+        request_line: GET /healthz HTTP/1.0
+        port: 80
+        interval: 2000
+        response_timeout: 2000
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+    retain_ip: true
+
+etcd:
+    retain_ip: true
+    scale_policy:
+        increment: 1
+        max: 3
+        min: 1
+    health_check:
+        port: 2378
+        request_line: GET /health HTTP/1.0
+        interval: 5000
+        response_timeout: 3000
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+        recreate_on_quorum_strategy_config:
+            quorum: 2
+        strategy: recreateOnQuorum
+
+rancher-kubernetes-agent:
+    health_check:
+        request_line: GET /healthcheck HTTP/1.0
+        port: 10240
+        interval: 2000
+        response_timeout: 2000
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+
+scheduler:
+    health_check:
+        request_line: GET /healthz HTTP/1.0
+        port: 10251
+        interval: 2000
+        response_timeout: 2000
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+
+controller-manager:
+    health_check:
+        request_line: GET /healthz HTTP/1.0
+        port: 10252
+        interval: 2000
+        response_timeout: 2000
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+
+kubectld:
+    health_check:
+        port: 8091
+        interval: 2000
+        response_timeout: 2000
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+
+
+rancher-ingress-controller:
+    health_check:
+        request_line: GET /healthz HTTP/1.0
+        port: 10241
+        interval: 2000
+        response_timeout: 2000
+        unhealthy_threshold: 3
+        healthy_threshold: 2

--- a/infra-templates/k8s/config.yml
+++ b/infra-templates/k8s/config.yml
@@ -1,5 +1,5 @@
 name: Kubernetes
-version: v1.4.6-rancher1
+version: v1.4.6-rancher2-1
 category: Orchestration
 labels:
   io.rancher.certified: rancher


### PR DESCRIPTION
Needs to use a newer rancher/k8s (rancher/k8s:v1.4.6-rancher3) image for kubedns-starter, built off rancher/kubernetes-package#4