### PR TITLE
1.4.0-RC2: storage templates update with go-rancher-metadata fix

### DIFF
--- a/infra-templates/ebs/2/docker-compose.yml
+++ b/infra-templates/ebs/2/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   ebs-driver:
     privileged: true
     network_mode: host
-    image: rancher/storage-ebs:v0.6.1
+    image: rancher/storage-ebs:v0.6.2
     labels:
       io.rancher.scheduler.global: 'true'
       io.rancher.container.create_agent: 'true'

--- a/infra-templates/efs/2/docker-compose.yml
+++ b/infra-templates/efs/2/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   efs-driver:
     privileged: true
     network_mode: host
-    image: rancher/storage-efs:v0.6.1
+    image: rancher/storage-efs:v0.6.2
     pid: host
     labels:
       io.rancher.scheduler.global: 'true'

--- a/infra-templates/nfs/2/docker-compose.yml
+++ b/infra-templates/nfs/2/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
   nfs-driver:
     privileged: true
-    image: rancher/storage-nfs:v0.6.1
+    image: rancher/storage-nfs:v0.6.2
     pid: host
     labels:
       io.rancher.scheduler.global: 'true'


### PR DESCRIPTION
@LLParse @deniseschannon these templates' folders were introduced only in 1.4 RC2 branch, so just updated them with the newer images having go-rancher-metadata fix