### PR TITLE
Upgrade Route53 infra template v0.6.2

### DIFF
--- a/infra-templates/route53/10/README.md
+++ b/infra-templates/route53/10/README.md
@@ -1,0 +1,86 @@
+## Route53 DNS
+
+Rancher External DNS service powered by Amazon Route53
+
+#### Changelog
+
+##### v0.6.2
+
+* Adds support for disabling/enforcing external DNS on the host and service level using labels
+* Fixes an issue with lingering TCP keep-alive connections to the Rancher Metadata service
+
+#### Usage
+
+##### Upgrade Notes
+While upgrading from a version lower than v0.6.0 the TTL configuration value should not be changed. You may change it once the upgrade has been completed.
+
+##### Limitation when running the service on multiple Rancher servers
+
+When running multiple instances of the External DNS service configured to use the same domain name, then only one of them can run in the "Default" environment of a Rancher server instance.
+
+##### Supported host labels
+
+`io.rancher.host.external_dns_ip`     
+Override the IP address used in DNS records for containers running on the host. Defaults to the IP address the host is registered with in Rancher.
+      
+`io.rancher.host.external_dns`    
+Accepts 'true' (default) or 'false'    
+When this is set to 'false' no DNS records will ever be created for containers running on this host.
+
+##### Supported service labels
+
+`io.rancher.service.external_dns`     
+Accepts 'always', 'never' or 'auto' (default)  
+- `always`: Always create DNS records for this service
+- `never`: Never create DNS records for this service
+- `auto`: Create DNS records for this service if it exposes ports on the host
+     
+##### Custom DNS name template
+
+By default DNS entries are named `<service>.<stack>.<environment>.<domain>`.    
+You can specify a custom name template used to construct the subdomain part (left of the domain/zone name) of the DNS records. The following placeholders are supported:
+
+* `%{{service_name}}`
+* `%{{stack_name}}`
+* `%{{environment_name}}`
+
+**Example:**
+
+`%{{stack_name}}-%{{service_name}}.statictext`
+
+Make sure to only use characters in static text and separators that your provider allows in DNS names.
+
+##### Required AWS IAM permissions
+The following IAM policy describes the minimum set of permissions needed for Route53 DNS to work.
+Make sure that the AWS security credentials (Access Key ID / Secret Access Key) that you are specifying have been granted at least these permissions.
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "route53:GetHostedZone",
+                "route53:GetHostedZoneCount",
+                "route53:ListHostedZonesByName",
+                "route53:ListResourceRecordSets"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "route53:ChangeResourceRecordSets"
+            ],
+            "Resource": [
+                "arn:aws:route53:::hostedzone/<HOSTED_ZONE_ID>"
+            ]
+        }
+    ]
+}
+``` 
+
+Note: When using this JSON document to create a custom IAM policy in AWS, replace `<HOSTED_ZONE_ID>` with the ID of the Route53 hosted zone or use a wildcard ('*').

--- a/infra-templates/route53/10/docker-compose.yml
+++ b/infra-templates/route53/10/docker-compose.yml
@@ -1,0 +1,16 @@
+route53:
+  image: rancher/external-dns:v0.6.2
+  command: -provider=route53
+  expose:
+   - 1000
+  environment:
+    AWS_ACCESS_KEY: ${AWS_ACCESS_KEY}
+    AWS_SECRET_KEY: ${AWS_SECRET_KEY}
+    AWS_REGION: ${AWS_REGION}
+    ROOT_DOMAIN: ${ROOT_DOMAIN}
+    ROUTE53_ZONE_ID: ${ROUTE53_ZONE_ID}
+    NAME_TEMPLATE: ${NAME_TEMPLATE}
+    TTL: ${TTL}
+  labels:
+    io.rancher.container.create_agent: "true"
+    io.rancher.container.agent.role: "external-dns"

--- a/infra-templates/route53/10/rancher-compose.yml
+++ b/infra-templates/route53/10/rancher-compose.yml
@@ -1,0 +1,66 @@
+.catalog:
+  name: "Route53 DNS"
+  version: "v0.6.2-rancher1"
+  description: "Rancher External DNS service powered by Amazon Route53. Requires Rancher version v1.1.0"
+  minimum_rancher_version: v1.1.0
+  questions:
+    - variable: "AWS_ACCESS_KEY"
+      label: "AWS Access Key ID"
+      description: "Access key ID for your AWS account"
+      type: "string"
+      required: true
+    - variable: "AWS_SECRET_KEY"
+      label: "AWS Secret Access Key"
+      description: "Secret access key for your AWS account"
+      type: "string"
+      required: true
+    - variable: "AWS_REGION"
+      label: "AWS Region"
+      description: "AWS region name"
+      type: "string"
+      default: "us-west-2"
+      required: true
+    - variable: "TTL"
+      label: "TTL"
+      description: "The resource record cache time to live (TTL), in seconds"
+      type: "int"
+      default: 60
+      required: false
+    - variable: "ROOT_DOMAIN"
+      label: "Hosted Zone Name"
+      description: "Route53 hosted zone name (zone has to be pre-created)."
+      type: "string"
+      required: true
+    - variable: "ROUTE53_ZONE_ID"
+      label: "Hosted Zone ID"
+      description: "If there are multiple zones with the same name, then you must additionally specify the ID of the hosted zone to use."
+      type: "string"
+      required: false
+    - variable: "NAME_TEMPLATE"
+      label: "DNS Name Template"
+      description: |
+        Name template used to construct the subdomain part (left of the hosted zone name) of the DNS record names.
+        Supported placeholders: %{{service_name}}, %{{stack_name}}, %{{environment_name}}.
+        By default DNS entries will be named '<service>.<stack>.<environment>.<domain>'.
+      type: "string"
+      default: "%{{service_name}}.%{{stack_name}}.%{{environment_name}}"
+      required: false
+    - variable: "HEALTH_CHECK"
+      label: "Health Check Interval"
+      description: |
+        The health check interval for this service, in milliseconds.
+        Raise this value if the global requests for your account are exceeding the Route53 API rate limits.
+      type: "int"
+      min: 2000
+      max: 60000
+      default: 10000
+      required: true
+
+route53:
+  health_check:
+    port: 1000
+    interval: ${HEALTH_CHECK}
+    unhealthy_threshold: 2
+    request_line: GET / HTTP/1.0
+    healthy_threshold: 2
+    response_timeout: 5000

--- a/infra-templates/route53/config.yml
+++ b/infra-templates/route53/config.yml
@@ -1,7 +1,7 @@
 name: Route53 DNS
 description: |
   Rancher External DNS service powered by Amazon Route53
-version: v0.6.1-rancher1
+version: v0.6.2-rancher1
 category: External DNS
 labels:
   io.rancher.certified: rancher


### PR DESCRIPTION
Depends on `rancher/external-dns:v0.6.2`