### PR TITLE
kubelet mount host volume /var/log/containers

### DIFF
--- a/infra-templates/k8s/14/docker-compose.yml
+++ b/infra-templates/k8s/14/docker-compose.yml
@@ -23,6 +23,7 @@ kubelet:
         - /var/run:/var/run
         - /var/lib/docker:/var/lib/docker
         - /var/lib/kubelet:/var/lib/kubelet:shared
+        - /var/log/containers:/var/log/containers
         - rancher-cni-driver:/etc/cni:ro
         - rancher-cni-driver:/opt/cni:ro
         - /dev:/host/dev

--- a/infra-templates/k8s/17/docker-compose.yml
+++ b/infra-templates/k8s/17/docker-compose.yml
@@ -23,6 +23,7 @@ kubelet:
         - /var/run:/var/run
         - /var/lib/docker:/var/lib/docker
         - /var/lib/kubelet:/var/lib/kubelet:shared
+        - /var/log/containers:/var/log/containers
         - rancher-cni-driver:/etc/cni:ro
         - rancher-cni-driver:/opt/cni:ro
         - /dev:/host/dev

--- a/infra-templates/k8s/18/docker-compose.yml
+++ b/infra-templates/k8s/18/docker-compose.yml
@@ -25,6 +25,7 @@ kubelet:
         - /sys:/sys:ro
         - /var/lib/docker:/var/lib/docker
         - /var/lib/kubelet:/var/lib/kubelet:shared
+        - /var/log/containers:/var/log/containers
         - rancher-cni-driver:/etc/cni:ro
         - rancher-cni-driver:/opt/cni:ro
         - /dev:/host/dev


### PR DESCRIPTION
Kubernetes addon fluentd-elasticsearch not work.  The Kubernetes kubelet makes a symbolic link to this file on the contrainer in the /var/log/containers directory, not on the host machine.