### PR TITLE
Udpates to net-services

### DIFF
--- a/infra-templates/network-services/10/docker-compose.yml
+++ b/infra-templates/network-services/10/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   network-manager:
-    image: rancher/network-manager:v0.4.5
+    image: rancher/network-manager:v0.4.6
     privileged: true
     network_mode: host
     pid: host
@@ -12,6 +12,7 @@ services:
     volumes:
     - /var/run/docker.sock:/var/run/docker.sock
     - /var/lib/docker:/var/lib/docker
+    - /var/lib/rancher/state:/var/lib/rancher/state
     - /lib/modules:/lib/modules:ro
     - /run:/run:ro
     - /var/run:/var/run:ro


### PR DESCRIPTION
Add /var/lib/rancher/state bind mount so that container network state
and errors can be propogated to rancher-agent.

Upgrade to network-services:v0.4.6 to remove the check for the
io.rancher.container.system label when setting resolv.conf. It isn't
needed and was causing problems once we started setting that label on
all containers belonging to system stacks.