### PR TITLE
add script to determine version of various infra images

### DIFF
--- a/scripts/k8s_version.sh
+++ b/scripts/k8s_version.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+cd $(dirname $0)/../infra-templates/k8s/
+
+FILES="./*"
+
+for f in $FILES; do
+    if [ -d $f ] ; then
+        VERSION=$(grep "^  version:" $f/rancher-compose.yml | cut -d: -f2 | awk '{print $1}' | sed 's/"//g')
+        if [ $VERSION == $1 ]; then
+           printf "Found template version $1\n"
+           printf "\nInfra images:\n"
+           RANCHER_K8S_VERSION=$(grep "image:" $f/docker-compose.* |  awk '{print $2}' | sort | uniq | grep "rancher/k8s")
+           printf "%-60s %-60s\n" "Rancher Kubernetes version:" "$RANCHER_K8S_VERSION" 
+           ETCD_VERSION=$(grep "image:" $f/docker-compose.* |  awk '{print $2}' | sort | uniq | grep "rancher/etcd")
+           printf "%-60s %-60s\n" "ETCD version:" "$ETCD_VERSION"
+           HOSTNAME_UPDATER_VERSION=$(grep "image:" $f/docker-compose.* |  awk '{print $2}' | sort | uniq | grep "rancher/etc-host-updater")
+           printf "%-60s %-60s\n" "Hostname updater version:" "$HOSTNAME_UPDATER_VERSION"
+           KUBECTLD_VERSION=$(grep "image:" $f/docker-compose.* |  awk '{print $2}' | sort | uniq | grep "rancher/kubectld")
+           printf "%-60s %-60s\n" "Kubectld version:" "$KUBECTLD_VERSION"
+           RANCHER_K8S_AGENT=$(grep "image:" $f/docker-compose.* |  awk '{print $2}' | sort | uniq | grep "rancher/kubernetes-agent")
+           printf "%-60s %-60s\n" "Rancher Kubernetes Agent version:" "$RANCHER_K8S_AGENT"
+           RANCHER_LB_CONTR=$(grep "image:" $f/docker-compose.* |  awk '{print $2}' | sort | uniq | grep "rancher/lb-service-rancher")
+           printf "%-60s %-60s\n" "Rancher LB Controller version:" "$RANCHER_LB_CONTR"
+
+           printf "\nAddons:\n"
+
+           cd $OLDPWD
+           git clone http://github.com/rancher/kubernetes-package/ > /dev/null 2>&1
+           
+           cd kubernetes-package
+           git checkout $VERSION > /dev/null 2>&1 
+           if [ -d addon-templates/dashboard ]; then
+                DASHBOARD_VERSION=$(grep "image:" addon-templates/dashboard/dashboard-controller.* | sed 's/\$GCR_IO_REGISTRY/gcr.io/g' | sed 's/$DOCKER_IO_REGISTRY/docker.io/g' | awk '{print $2}')
+                printf "%-60s %-60s\n" "Kubernetes Addon: Kubernetes Dashboard version:" "$DASHBOARD_VERSION"
+           fi
+           if [ -d addon-templates/heapster ]; then
+                HEAPSTER_VERSION=$(grep "image:" addon-templates/heapster/heapster-controller.* | sed 's/\$GCR_IO_REGISTRY/gcr.io/g' | sed 's/$DOCKER_IO_REGISTRY/docker.io/g' | awk '{print $2}')
+                printf "%-60s %-60s\n" "Kubernetes Addon: Heapster version:" "$HEAPSTER_VERSION"
+                HEAPSTER_INFLUXDB_VERSION=$(grep "image:" addon-templates/heapster/influx-grafana-controller.* | grep influxdb | sed 's/\$GCR_IO_REGISTRY/gcr.io/g' | sed 's/$DOCKER_IO_REGISTRY/docker.io/g' | awk '{print $2}')
+                printf "%-60s %-60s\n" "Kuberentes Addon: Heapster InfluxDB version:" "$HEAPSTER_INFLUXDB_VERSION"
+                HEAPSTER_GRAFANA_VERSION=$(grep "image:" addon-templates/heapster/influx-grafana-controller.* | grep grafana | sed 's/\$GCR_IO_REGISTRY/gcr.io/g' | sed 's/$DOCKER_IO_REGISTRY/docker.io/g' | awk '{print $2}')
+                printf "%-60s %-60s\n" "Kubernetes Addon: Heapster Grafana version:" "$HEAPSTER_GRAFANA_VERSION"
+           fi
+           if [ -d addon-templates/helm ];then
+                TILLER_VERSION=$(grep "image:" addon-templates/helm/tiller-deploy.* | sed 's/\$GCR_IO_REGISTRY/gcr.io/g' | sed 's/$DOCKER_IO_REGISTRY/docker.io/g' | awk '{print $2}')
+                printf "%-60s %-60s\n" "Kubernetes Addon: Tiller version:" "$TILLER_VERSION"
+           fi
+
+           printf "\nWarn: Could not determine version of kube-dns\n"
+
+           cd ..
+           rm -rf kubernetes-package
+
+           exit 0 
+        fi 
+    fi
+done
+
+printf "could not find version $1\n"
+exit 1


### PR DESCRIPTION
@deniseschannon 

This is what the output looks like

```
Sidharthas-MacBook-Pro:rancher-catalog sidharthamani$ ./scripts/k8s_version.sh v1.5.2-rancher1-3
Found template version v1.5.2-rancher1-3

Infra images:
Rancher Kubernetes version:                                  rancher/k8s:v1.5.2-rancher1-3
ETCD version:                                                rancher/etcd:v2.3.7-11
Hostname updater version:                                    rancher/etc-host-updater:v0.0.2
Kubectld version:                                            rancher/kubectld:v0.5.4
Rancher Kubernetes Agent version:                            rancher/kubernetes-agent:v0.5.4
Rancher LB Controller version:                               rancher/lb-service-rancher:v0.6.1

Addons:
Kubernetes Addon: Kubernetes Dashboard version:              gcr.io/google_containers/kubernetes-dashboard-amd64:v1.5.0
Kubernetes Addon: Heapster version:                          gcr.io/google_containers/heapster:v1.2.0
Kuberentes Addon: Heapster InfluxDB version:                 docker.io/kubernetes/heapster_influxdb:v0.5
Kubernetes Addon: Heapster Grafana version:                  gcr.io/google_containers/heapster_grafana:v2.6.0-2
Kubernetes Addon: Tiller version:                            "gcr.io/kubernetes-helm/tiller:v2.1.3"

Warn: Could not determine version of kube-dns
```
A different version with only some addons:
```
Sidharthas-MacBook-Pro:rancher-catalog sidharthamani$ ./scripts/k8s_version.sh v1.5.1-rancher1-7
Found template version v1.5.1-rancher1-7

Infra images:
Rancher Kubernetes version:                                  rancher/k8s:v1.5.1-rancher1-7
ETCD version:                                                rancher/etcd:v2.3.7-11
Hostname updater version:                                    rancher/etc-host-updater:v0.0.2
Kubectld version:                                            rancher/kubectld:v0.5.3
Rancher Kubernetes Agent version:                            rancher/kubernetes-agent:v0.5.1
Rancher LB Controller version:                               rancher/lb-service-rancher:v0.5.0

Addons:
Kubernetes Addon: Kubernetes Dashboard version:              gcr.io/google_containers/kubernetes-dashboard-amd64:v1.5.0
Kubernetes Addon: Tiller version:                            "gcr.io/kubernetes-helm/tiller:v2.1.3"

Warn: Could not determine version of kube-dns
```

Older version without any addons:
```
Sidharthas-MacBook-Pro:rancher-catalog sidharthamani$ ./scripts/k8s_version.sh v1.4.6-rancher2-4
Found template version v1.4.6-rancher2-4

Infra images:
Rancher Kubernetes version:                                  rancher/k8s:v1.4.6-rancher2-4
ETCD version:                                                rancher/etcd:v2.3.7-11
Hostname updater version:                                    rancher/etc-host-updater:v0.0.2
Kubectld version:                                            rancher/kubectld:v0.4.0
Rancher Kubernetes Agent version:                            rancher/kubernetes-agent:v0.4.7
Rancher LB Controller version:                               rancher/lb-service-rancher:v0.4.7

Addons:

Warn: Could not determine version of kube-dns
```