### PR TITLE
Set net.ipv4.xfrm4_gc_thresh to INT_MAX

### DIFF
--- a/infra-templates/ipsec/5/docker-compose.yml
+++ b/infra-templates/ipsec/5/docker-compose.yml
@@ -36,6 +36,7 @@ services:
       net.ipv4.conf.all.send_redirects: '0'
       net.ipv4.conf.default.send_redirects: '0'
       net.ipv4.conf.eth0.send_redirects: '0'
+      net.ipv4.xfrm4_gc_thresh: '2147483647'
   cni-driver:
     privileged: true
     image: rancher/net:v0.11.2


### PR DESCRIPTION
Upstream Linux kernels set xfrm4_gc_thresh to INT_MAX now but some
kernels are old or have issues with propagating that setting to new
namespaces.  So we will force it to that.