### PR TITLE
Run kube-proxy on all nodes

### DIFF
--- a/infra-templates/k8s/28/docker-compose.yml.tpl
+++ b/infra-templates/k8s/28/docker-compose.yml.tpl
@@ -91,9 +91,6 @@ proxy:
     labels:
         io.rancher.container.dns: "true"
         io.rancher.scheduler.global: "true"
-        {{- if eq .Values.CONSTRAINT_TYPE "required" }}
-        io.rancher.scheduler.affinity:host_label: compute=true
-        {{- end }}
     command:
         - kube-proxy
         - --master=https://kubernetes.kubernetes.rancher.internal:6443


### PR DESCRIPTION
We're already running a kubelet on all nodes (unschedulable for orchestration/etcd). We should also be running kube-proxy on orchestration/etcd to finish the job.

rancher/rancher#8397