### PR TITLE
Remove RBAC alpha flag

### DIFF
--- a/infra-templates/k8s/28/docker-compose.yml.tpl
+++ b/infra-templates/k8s/28/docker-compose.yml.tpl
@@ -146,7 +146,6 @@ kubernetes:
         - --runtime-config=authentication.k8s.io/v1beta1=true
         {{- if eq .Values.RBAC "true" }}
         - --authorization-mode=RBAC
-        - --runtime-config=rbac.authorization.k8s.io/v1alpha1=true
         {{- end }}
     environment:
         KUBERNETES_URL: https://kubernetes.kubernetes.rancher.internal:6443


### PR DESCRIPTION
This flag isn't needed in Kubernetes 1.6.