### PR TITLE
WIP: HA Kubernetes

### DIFF
--- a/infra-templates/k8s/28/rancher-compose.yml
+++ b/infra-templates/k8s/28/rancher-compose.yml
@@ -86,10 +86,8 @@
     required: true
     default: 5000
     type: int
-kubernetes:
-    metadata:
-        sans:
-        - "IP:10.43.0.1"
+
+orch:
     health_check:
         port: 6443
         interval: 2000
@@ -98,7 +96,12 @@ kubernetes:
         healthy_threshold: 2
         initializing_timeout: 60000
         reinitializing_timeout: 60000
-    retain_ip: true
+
+#kubernetes:
+#    metadata:
+#        sans:
+#        - "IP:10.43.0.1"
+#    retain_ip: true
 
 etcd:
     retain_ip: true
@@ -123,28 +126,6 @@ rancher-kubernetes-agent:
     health_check:
         request_line: GET /healthcheck HTTP/1.0
         port: 10240
-        interval: 2000
-        response_timeout: 2000
-        unhealthy_threshold: 3
-        healthy_threshold: 2
-        initializing_timeout: 60000
-        reinitializing_timeout: 60000
-
-scheduler:
-    health_check:
-        request_line: GET /healthz HTTP/1.0
-        port: 10251
-        interval: 2000
-        response_timeout: 2000
-        unhealthy_threshold: 3
-        healthy_threshold: 2
-        initializing_timeout: 60000
-        reinitializing_timeout: 60000
-
-controller-manager:
-    health_check:
-        request_line: GET /healthz HTTP/1.0
-        port: 10252
         interval: 2000
         response_timeout: 2000
         unhealthy_threshold: 3


### PR DESCRIPTION
Depends on rancher/kubernetes-package#67. rancher/rancher#6305 is probably a requirement since we need to keep healthchecks on controller manager and scheduler.

The API server is set to be a global service when running with isolated planes. A load balancer is deployed in front of the API servers and its IP is used for the `advertise-address` flag. Controller manager and scheduler are switched to be sidekicks of the API server.

Nothing around etcd is touched since that's more in the realm of #667. Any other improvements around the isolated planes UX can be handled separately since this PR will work with how isolated planes are handled today.

rancher/rancher#8914