### PR TITLE
rancher/metadta:v0.9.2

### DIFF
--- a/infra-templates/network-services/20/docker-compose.yml
+++ b/infra-templates/network-services/20/docker-compose.yml
@@ -28,7 +28,7 @@ services:
   metadata:
     cap_add:
     - NET_ADMIN
-    image: rancher/metadata:v0.9.1
+    image: rancher/metadata:v0.9.2
     network_mode: bridge
     command: start.sh rancher-metadata -subscribe
     labels:


### PR DESCRIPTION
A fix for timing out on metadata's websocket connection handshake with
the rancher api.