### PR TITLE
Add subnetPrefix support

### DIFF
--- a/infra-templates/ipsec/9/docker-compose.yml
+++ b/infra-templates/ipsec/9/docker-compose.yml
@@ -1,0 +1,53 @@
+version: '2'
+services:
+  ipsec:
+    # IMPORTANT!!!! DO NOT CHANGE VERSION ON UPGRADE
+    image: rancher/net:holder
+    command: sh -c "echo Refer to router sidekick for logs; mkfifo f; exec cat f"
+    network_mode: ipsec
+    ports:
+      - 500:500/udp
+      - 4500:4500/udp
+    # Force cni-driver to start first
+    volumes_from:
+      - cni-driver
+    labels:
+      io.rancher.sidekicks: router,cni-driver
+      io.rancher.scheduler.global: 'true'
+      io.rancher.cni.link_mtu_overhead: '0'
+      io.rancher.network.macsync: 'true'
+      io.rancher.network.arpsync: 'true'
+  router:
+    cap_add:
+      - NET_ADMIN
+    image: rancher/net:v0.11.2
+    network_mode: container:ipsec
+    environment:
+      RANCHER_DEBUG: '${RANCHER_DEBUG}'
+    labels:
+      io.rancher.container.create_agent: 'true'
+      io.rancher.container.agent_service.ipsec: 'true'
+    logging:
+      driver: json-file
+      options:
+        max-size: 25m
+        max-file: '2'
+    sysctls:
+      net.ipv4.conf.all.send_redirects: '0'
+      net.ipv4.conf.default.send_redirects: '0'
+      net.ipv4.conf.eth0.send_redirects: '0'
+      net.ipv4.xfrm4_gc_thresh: '2147483647'
+  cni-driver:
+    privileged: true
+    image: rancher/net:v0.11.2
+    command: sh -c "touch /var/log/rancher-cni.log && exec tail ---disable-inotify -F /var/log/rancher-cni.log"
+    network_mode: host
+    pid: host
+    labels:
+      io.rancher.network.cni.binary: 'rancher-bridge'
+      io.rancher.container.dns: 'true'
+    logging:
+      driver: json-file
+      options:
+        max-size: 25m
+        max-file: '2'

--- a/infra-templates/ipsec/9/rancher-compose.yml
+++ b/infra-templates/ipsec/9/rancher-compose.yml
@@ -1,6 +1,6 @@
 .catalog:
-  name: "Rancher VXLAN"
-  version: "v0.1.1"
+  name: "Rancher IPsec"
+  version: "0.1.1"
   minimum_rancher_version: v1.6.0-alpha1
   questions:
     - variable: "DOCKER_BRIDGE"
@@ -17,7 +17,7 @@
       type: int
     - variable: "SUBNET"
       label: "Subnet"
-      description: "The subnet to use for the managed network."
+      description: "The subnet to use for the managed IPSEC network."
       type: "string"
       default: '10.42.0.0/16'
       required: true
@@ -26,6 +26,7 @@
       description: "The Subnet prefix to use for the managed network. For most users this is same as the bridge subnet prefix. Ex: 16 if using 10.42.0.1/16 for bridge subnet."
       type: int
       default: 16
+      required: true
     - variable: "RANCHER_DEBUG"
       label: "Enable Debug Logs"
       description: "This will enable very verbose debug logs."
@@ -33,11 +34,11 @@
       default: "false"
       required: true
 
-vxlan:
+ipsec:
   network_driver:
-    name: Rancher VXLAN
+    name: Rancher IPsec
     default_network:
-      name: vxlan
+      name: ipsec
       host_ports: true
       subnets:
       - network_address: $SUBNET
@@ -46,7 +47,7 @@ vxlan:
       dns_search:
       - rancher.internal
     cni_config:
-      '10-rancher-vxlan.conf':
+      '10-rancher.conf':
         name: rancher-cni-network
         type: rancher-bridge
         bridge: $DOCKER_BRIDGE
@@ -54,15 +55,14 @@ vxlan:
         logToFile: /var/log/rancher-cni.log
         isDebugLevel: ${RANCHER_DEBUG}
         isDefaultGateway: true
-        hairpinMode: true
         hostNat: true
         hairpinMode: true
         mtu: ${MTU}
-        linkMTUOverhead: 50
+        linkMTUOverhead: 98
         ipam:
           type: rancher-cni-ipam
           subnetPrefixSize: /${SUBNET_PREFIX}
           logToFile: /var/log/rancher-cni.log
           isDebugLevel: ${RANCHER_DEBUG}
           routes:
-            - dst: 169.254.169.250/32
+          - dst: 169.254.169.250/32

--- a/infra-templates/vxlan/9/docker-compose.yml
+++ b/infra-templates/vxlan/9/docker-compose.yml
@@ -1,0 +1,42 @@
+version: '2'
+services:
+  vxlan:
+    cap_add:
+      - NET_ADMIN
+    image: rancher/net:v0.11.2
+    network_mode: vxlan
+    environment:
+      RANCHER_DEBUG: '${RANCHER_DEBUG}'
+    command: start-vxlan.sh
+    ports:
+      - 4789:4789/udp
+    # Force cni-driver to start first
+    volumes_from:
+      - cni-driver
+    labels:
+      io.rancher.sidekicks: cni-driver
+      io.rancher.scheduler.global: 'true'
+      io.rancher.container.create_agent: 'true'
+      io.rancher.container.agent_service.vxlan: 'true'
+      io.rancher.cni.link_mtu_overhead: '0'
+      io.rancher.network.macsync: 'true'
+      io.rancher.network.arpsync: 'true'
+    logging:
+      driver: json-file
+      options:
+        max-size: 25m
+        max-file: '2'
+  cni-driver:
+    privileged: true
+    image: rancher/net:v0.11.2
+    command: sh -c "touch /var/log/rancher-cni.log && exec tail ---disable-inotify -F /var/log/rancher-cni.log"
+    network_mode: host
+    pid: host
+    labels:
+      io.rancher.network.cni.binary: 'rancher-bridge'
+      io.rancher.container.dns: 'true'
+    logging:
+      driver: json-file
+      options:
+        max-size: 25m
+        max-file: '2'

--- a/infra-templates/vxlan/9/docker-compose.yml
+++ b/infra-templates/vxlan/9/docker-compose.yml
@@ -19,6 +19,8 @@ services:
       io.rancher.container.create_agent: 'true'
       io.rancher.container.agent_service.vxlan: 'true'
       io.rancher.cni.link_mtu_overhead: '0'
+      io.rancher.internal.service.vxlan: 'true'
+      io.rancher.service.selector.link: io.rancher.internal.service.vxlan=true
       io.rancher.network.macsync: 'true'
       io.rancher.network.arpsync: 'true'
     logging:

--- a/infra-templates/vxlan/9/rancher-compose.yml
+++ b/infra-templates/vxlan/9/rancher-compose.yml
@@ -1,0 +1,68 @@
+.catalog:
+  name: "Rancher VXLAN"
+  version: "v0.0.5-a"
+  minimum_rancher_version: v1.4.0-rc1
+  maximum_rancher_version: v1.4.99
+  questions:
+    - variable: "DOCKER_BRIDGE"
+      label: "Docker Bridge"
+      description: "Name of Docker Bridge. Default is `docker0`"
+      type: "string"
+      default: "docker0"
+      required: true
+    - variable: MTU
+      label: "MTU for the network"
+      description: "Adjust the MTU for the network, according to your needs. Ex: GCE(1460), AWS(1500), etc"
+      required: true
+      default: 1500
+      type: int
+    - variable: "SUBNET"
+      label: "Subnet"
+      description: "The subnet to use for the managed network."
+      type: "string"
+      default: '10.42.0.0/16'
+    - variable: "SUBNET_PREFIX"
+      label: "Subnet Prefix"
+      description: "The Subnet prefix to use for the managed network."
+      type: int
+      default: 16
+    - variable: "RANCHER_DEBUG"
+      label: "Enable Debug Logs"
+      description: "This will enable very verbose debug logs."
+      type: "boolean"
+      default: "false"
+      required: true
+
+vxlan:
+  network_driver:
+    name: Rancher VXLAN
+    default_network:
+      name: vxlan
+      host_ports: true
+      subnets:
+      - network_address: $SUBNET
+      dns:
+      - 169.254.169.250
+      dns_search:
+      - rancher.internal
+    cni_config:
+      '10-rancher-vxlan.conf':
+        name: rancher-cni-network
+        type: rancher-bridge
+        bridge: $DOCKER_BRIDGE
+        bridgeSubnet: $SUBNET
+        logToFile: /var/log/rancher-cni.log
+        isDebugLevel: ${RANCHER_DEBUG}
+        isDefaultGateway: true
+        hairpinMode: true
+        hostNat: true
+        hairpinMode: true
+        mtu: ${MTU}
+        linkMTUOverhead: 50
+        ipam:
+          type: rancher-cni-ipam
+          subnetPrefixSize: /${SUBNET_PREFIX}
+          logToFile: /var/log/rancher-cni.log
+          isDebugLevel: ${RANCHER_DEBUG}
+          routes:
+            - dst: 169.254.169.250/32

--- a/infra-templates/vxlan/9/rancher-compose.yml
+++ b/infra-templates/vxlan/9/rancher-compose.yml
@@ -1,8 +1,7 @@
 .catalog:
   name: "Rancher VXLAN"
-  version: "v0.0.5-a"
-  minimum_rancher_version: v1.4.0-rc1
-  maximum_rancher_version: v1.4.99
+  version: "v0.1.1"
+  minimum_rancher_version: v1.6.0-alpha1
   questions:
     - variable: "DOCKER_BRIDGE"
       label: "Docker Bridge"
@@ -21,6 +20,7 @@
       description: "The subnet to use for the managed network."
       type: "string"
       default: '10.42.0.0/16'
+      required: true
     - variable: "SUBNET_PREFIX"
       label: "Subnet Prefix"
       description: "The Subnet prefix to use for the managed network."

--- a/infra-templates/vxlan/9/rancher-compose.yml
+++ b/infra-templates/vxlan/9/rancher-compose.yml
@@ -26,6 +26,7 @@
       description: "The Subnet prefix to use for the managed network. For most users this is same as the bridge subnet prefix. Ex: 16 if using 10.42.0.1/16 for bridge subnet."
       type: int
       default: 16
+      required: true
     - variable: "RANCHER_DEBUG"
       label: "Enable Debug Logs"
       description: "This will enable very verbose debug logs."

--- a/infra-templates/vxlan/config.yml
+++ b/infra-templates/vxlan/config.yml
@@ -1,7 +1,7 @@
 name: Rancher VXLAN
 description: |
   Rancher Networking plugin using VXLAN overlay.
-version: v0.1.0
+version: v0.1.1
 category: Networking
 labels:
   io.rancher.certified: rancher


### PR DESCRIPTION
This PR adds support for adding subnetPrefix to the rancher catalog for both vxlan and ipsec networks. For further information, please see the original thread discussion here: https://github.com/rancher/rancher/issues/8938