### PR TITLE
Add new logging location to mount list for kubelet

### DIFF
--- a/infra-templates/k8s/29/docker-compose.yml.tpl
+++ b/infra-templates/k8s/29/docker-compose.yml.tpl
@@ -37,6 +37,7 @@ kubelet:
         - /var/lib/docker:/var/lib/docker
         - /var/lib/kubelet:/var/lib/kubelet:shared
         - /var/log/containers:/var/log/containers
+        - /var/log/pods:/var/log/pods
         - rancher-cni-driver:/etc/cni:ro
         - rancher-cni-driver:/opt/cni:ro
         - /dev:/host/dev
@@ -84,6 +85,7 @@ kubelet-unschedulable:
         - /var/lib/docker:/var/lib/docker
         - /var/lib/kubelet:/var/lib/kubelet:shared
         - /var/log/containers:/var/log/containers
+        - /var/log/pods:/var/log/pods
         - rancher-cni-driver:/etc/cni:ro
         - rancher-cni-driver:/opt/cni:ro
         - /dev:/host/dev

--- a/infra-templates/k8s/30/docker-compose.yml.tpl
+++ b/infra-templates/k8s/30/docker-compose.yml.tpl
@@ -37,6 +37,7 @@ kubelet:
         - /var/lib/docker:/var/lib/docker
         - /var/lib/kubelet:/var/lib/kubelet:shared
         - /var/log/containers:/var/log/containers
+        - /var/log/pods:/var/log/pods
         - rancher-cni-driver:/etc/cni:ro
         - rancher-cni-driver:/opt/cni:ro
         - /dev:/host/dev
@@ -84,6 +85,7 @@ kubelet-unschedulable:
         - /var/lib/docker:/var/lib/docker
         - /var/lib/kubelet:/var/lib/kubelet:shared
         - /var/log/containers:/var/log/containers
+        - /var/log/pods:/var/log/pods
         - rancher-cni-driver:/etc/cni:ro
         - rancher-cni-driver:/opt/cni:ro
         - /dev:/host/dev


### PR DESCRIPTION
See https://github.com/kubernetes/kubernetes/issues/42718.  The symlink from `/var/log/containers` now points to `/var/log/pods`.  

 https://github.com/rancher/rancher/issues/7688.