### PR TITLE
Add new logging location to mount list for kubelet

### DIFF
--- a/infra-templates/k8s/28/docker-compose.yml.tpl
+++ b/infra-templates/k8s/28/docker-compose.yml.tpl
@@ -32,6 +32,7 @@ kubelet:
         - /var/lib/docker:/var/lib/docker
         - /var/lib/kubelet:/var/lib/kubelet:shared
         - /var/log/containers:/var/log/containers
+        - /var/log/pods:/var/log/pods
         - rancher-cni-driver:/etc/cni:ro
         - rancher-cni-driver:/opt/cni:ro
         - /dev:/host/dev
@@ -76,6 +77,7 @@ kubelet-unschedulable:
         - /var/lib/docker:/var/lib/docker
         - /var/lib/kubelet:/var/lib/kubelet:shared
         - /var/log/containers:/var/log/containers
+        - /var/log/pods:/var/log/pods
         - rancher-cni-driver:/etc/cni:ro
         - rancher-cni-driver:/opt/cni:ro
         - /dev:/host/dev


### PR DESCRIPTION
See kubernetes/kubernetes#42718. The symlink from /var/log/containers now points to /var/log/pods.

Fixes rancher/rancher#7688.