### PR TITLE
Rancher-dns : allow configurable TTL

### DIFF
--- a/infra-templates/network-services/20/rancher-compose.yml
+++ b/infra-templates/network-services/20/rancher-compose.yml
@@ -2,6 +2,7 @@
     name: Network Services
     version: v0.2.2
     minimum_rancher_version: v1.6.0-rc1
+    maximum_rancher_version: v1.6.1
     questions:
     - variable: DNS_RECURSER_TIMEOUT
       label: Timeout for Rancher DNS Recurser

--- a/infra-templates/network-services/21/docker-compose.yml
+++ b/infra-templates/network-services/21/docker-compose.yml
@@ -1,0 +1,54 @@
+version: '2'
+services:
+  network-manager:
+    image: rancher/network-manager:v0.7.4
+    privileged: true
+    network_mode: host
+    pid: host
+    command: plugin-manager --metadata-url http://169.254.169.250/2016-07-29
+    environment:
+      DOCKER_BRIDGE: docker0
+      METADATA_IP: 169.254.169.250
+    volumes:
+    - /var/run/docker.sock:/var/run/docker.sock
+    - /var/lib/docker:/var/lib/docker
+    - /var/lib/rancher/state:/var/lib/rancher/state
+    - /lib/modules:/lib/modules:ro
+    - /run:/run
+    - /var/run:/var/run:ro
+    - rancher-cni-driver:/etc/cni
+    - rancher-cni-driver:/opt/cni
+    labels:
+      io.rancher.scheduler.global: 'true'
+    logging:
+      driver: json-file
+      options:
+        max-size: 25m
+        max-file: '2'
+  metadata:
+    cap_add:
+    - NET_ADMIN
+    image: rancher/metadata:v0.9.2
+    network_mode: bridge
+    command: start.sh rancher-metadata -subscribe
+    labels:
+      io.rancher.sidekicks: dns
+      io.rancher.container.create_agent: 'true'
+      io.rancher.scheduler.global: 'true'
+      io.rancher.container.agent_service.metadata: 'true'
+    logging:
+      driver: json-file
+      options:
+        max-size: 25m
+        max-file: '2'
+  dns:
+    image: rancher/dns:v0.15.1
+    network_mode: container:metadata
+    command: rancher-dns --metadata-server=localhost --answers=/etc/rancher-dns/answers.json --recurser-timeout ${DNS_RECURSER_TIMEOUT}
+    labels:
+      io.rancher.scheduler.global: 'true'
+    logging:
+      driver: json-file
+      options:
+        max-size: 25m
+        max-file: '2'

--- a/infra-templates/network-services/21/docker-compose.yml
+++ b/infra-templates/network-services/21/docker-compose.yml
@@ -44,7 +44,7 @@ services:
   dns:
     image: rancher/dns:v0.15.1
     network_mode: container:metadata
-    command: rancher-dns --metadata-server=localhost --answers=/etc/rancher-dns/answers.json --recurser-timeout ${DNS_RECURSER_TIMEOUT}
+    command: rancher-dns --metadata-server=localhost --answers=/etc/rancher-dns/answers.json --recurser-timeout ${DNS_RECURSER_TIMEOUT} --ttl ${TTL}
     labels:
       io.rancher.scheduler.global: 'true'
     logging:

--- a/infra-templates/network-services/21/rancher-compose.yml
+++ b/infra-templates/network-services/21/rancher-compose.yml
@@ -1,0 +1,11 @@
+.catalog:
+    name: Network Services
+    version: v0.2.2
+    minimum_rancher_version: v1.6.0-rc1
+    questions:
+    - variable: DNS_RECURSER_TIMEOUT
+      label: Timeout for Rancher DNS Recurser
+      description: Specify timeout in seconds for DNS Recurser.
+      required: true
+      default: 2
+      type: int

--- a/infra-templates/network-services/21/rancher-compose.yml
+++ b/infra-templates/network-services/21/rancher-compose.yml
@@ -1,6 +1,6 @@
 .catalog:
     name: Network Services
-    version: v0.2.2
+    version: v0.2.4
     minimum_rancher_version: v1.6.0-rc1
     questions:
     - variable: DNS_RECURSER_TIMEOUT
@@ -8,4 +8,10 @@
       description: Specify timeout in seconds for DNS Recurser.
       required: true
       default: 2
+      type: int
+    - variable: TTL
+      label: Timeout for Internal Rancher DNS
+      description: Specify timeout in seconds for local requests.
+      required: true
+      default: 10
       type: int

--- a/infra-templates/network-services/21/rancher-compose.yml
+++ b/infra-templates/network-services/21/rancher-compose.yml
@@ -1,7 +1,7 @@
 .catalog:
     name: Network Services
     version: v0.2.4
-    minimum_rancher_version: v1.6.0-rc1
+    minimum_rancher_version: v1.6.1
     questions:
     - variable: DNS_RECURSER_TIMEOUT
       label: Timeout for Rancher DNS Recurser

--- a/infra-templates/network-services/21/rancher-compose.yml
+++ b/infra-templates/network-services/21/rancher-compose.yml
@@ -1,6 +1,6 @@
 .catalog:
     name: Network Services
-    version: v0.2.4
+    version: v0.2.3
     minimum_rancher_version: v1.6.1
     questions:
     - variable: DNS_RECURSER_TIMEOUT

--- a/infra-templates/network-services/config.yml
+++ b/infra-templates/network-services/config.yml
@@ -1,5 +1,5 @@
 name: Network Services
-version: v0.2.4
+version: v0.2.3
 category: Framework
 labels:
   io.rancher.certified: rancher

--- a/infra-templates/network-services/config.yml
+++ b/infra-templates/network-services/config.yml
@@ -1,5 +1,5 @@
 name: Network Services
-version: v0.2.2
+version: v0.2.4
 category: Framework
 labels:
   io.rancher.certified: rancher


### PR DESCRIPTION
[rancher/rancher#8805](https://github.com/rancher/rancher/issues/8805)

Allows launching catalog to set TTL in rancher-dns as required.
New default value - 10 seconds.

Network services -
version: v0.2.3