### PR TITLE
Add CNI subnetPrefix support

### DIFF
--- a/infra-templates/ipsec/11/README.md
+++ b/infra-templates/ipsec/11/README.md
@@ -1,0 +1,36 @@
+## IPSec Networking
+
+Rancher networking plugin using IPsec.
+
+### Open Ports
+
+Traffic to and from hosts require UDP ports `500` and `4500` to be open.
+
+#### Usage
+
+##### Configuration options
+* `RANCHER_DEBUG`
+
+###### [cni-driver]
+
+* `DOCKER_BRIDGE`
+* `MTU`
+* `SUBNET`
+* `SUBNET_PREFIX`
+* `RANCHER_HAIRPIN_MODE`
+* `RANCHER_PROMISCUOUS_MODE`
+* `HOST_PORTS`
+
+#### Changelog
+
+##### 0.1.3
+
+Add support for changing the IPAM subnet prefix size.
+
+##### 0.1.2
+
+This version removes the `cni-driver` service as a sidekick of the `ipsec` container and makes it standalone.
+
+###### [rancher/net:v0.11.4]
+* This image version doesn't have any specific changes for IPSec but the programming logic for VXLAN has been improved.
+

--- a/infra-templates/ipsec/11/docker-compose.yml.tpl
+++ b/infra-templates/ipsec/11/docker-compose.yml.tpl
@@ -1,0 +1,83 @@
+version: '2'
+services:
+  ipsec:
+    # IMPORTANT!!!! DO NOT CHANGE VERSION ON UPGRADE
+    image: rancher/net:holder
+    command: sh -c "echo Refer to router sidekick for logs; mkfifo f; exec cat f"
+    network_mode: ipsec
+    ports:
+      - 500:500/udp
+      - 4500:4500/udp
+    labels:
+      io.rancher.sidekicks: router
+      io.rancher.scheduler.global: 'true'
+      io.rancher.cni.link_mtu_overhead: '0'
+      io.rancher.network.macsync: 'true'
+      io.rancher.network.arpsync: 'true'
+  router:
+    cap_add:
+      - NET_ADMIN
+    image: rancher/net:v0.11.4
+    network_mode: container:ipsec
+    environment:
+      RANCHER_DEBUG: '${RANCHER_DEBUG}'
+    labels:
+      io.rancher.container.create_agent: 'true'
+      io.rancher.container.agent_service.ipsec: 'true'
+    logging:
+      driver: json-file
+      options:
+        max-size: 25m
+        max-file: '2'
+    sysctls:
+      net.ipv4.conf.all.send_redirects: '0'
+      net.ipv4.conf.default.send_redirects: '0'
+      net.ipv4.conf.eth0.send_redirects: '0'
+      net.ipv4.xfrm4_gc_thresh: '2147483647'
+  cni-driver:
+    privileged: true
+    image: rancher/net:v0.11.4
+    command: sh -c "touch /var/log/rancher-cni.log && exec tail ---disable-inotify -F /var/log/rancher-cni.log"
+    network_mode: host
+    pid: host
+    labels:
+      io.rancher.scheduler.global: 'true'
+      io.rancher.network.cni.binary: 'rancher-bridge'
+      io.rancher.container.dns: 'true'
+    logging:
+      driver: json-file
+      options:
+        max-size: 25m
+        max-file: '2'
+    network_driver:
+      name: Rancher IPsec
+      default_network:
+        name: ipsec
+        host_ports: {{ .Values.HOST_PORTS }}
+        subnets:
+        - network_address: $SUBNET
+        dns:
+        - 169.254.169.250
+        dns_search:
+        - rancher.internal
+      cni_config:
+        '10-rancher.conf':
+          name: rancher-cni-network
+          type: rancher-bridge
+          bridge: $DOCKER_BRIDGE
+          bridgeSubnet: $SUBNET
+          logToFile: /var/log/rancher-cni.log
+          isDebugLevel: ${RANCHER_DEBUG}
+          isDefaultGateway: true
+          hostNat: true
+          hairpinMode: {{  .Values.RANCHER_HAIRPIN_MODE }}
+          promiscMode: {{ .Values.RANCHER_PROMISCUOUS_MODE }}
+          mtu: ${MTU}
+          linkMTUOverhead: 98
+          ipam:
+            type: rancher-cni-ipam
+            subnetPrefixSize: /{{ .Values.SUBNET_PREFIX }}
+            logToFile: /var/log/rancher-cni.log
+            isDebugLevel: ${RANCHER_DEBUG}
+            routes:
+            - dst: 169.254.169.250/32

--- a/infra-templates/ipsec/11/rancher-compose.yml
+++ b/infra-templates/ipsec/11/rancher-compose.yml
@@ -1,0 +1,53 @@
+.catalog:
+  name: "Rancher IPsec"
+  version: "0.1.3"
+  minimum_rancher_version: v1.6.3-rc1
+  questions:
+    - variable: "DOCKER_BRIDGE"
+      label: "Docker Bridge"
+      description: "Name of Docker Bridge. Default is `docker0`"
+      type: "string"
+      default: "docker0"
+      required: true
+    - variable: MTU
+      label: "MTU for the network"
+      description: "Adjust the MTU for the network, according to your needs. Ex: GCE(1460), AWS(1500), etc"
+      required: true
+      default: 1500
+      type: int
+    - variable: "SUBNET"
+      label: "Subnet"
+      description: "The subnet to use for the managed IPSEC network."
+      type: "string"
+      default: '10.42.0.0/16'
+      required: true
+    - variable: "SUBNET_PREFIX"
+      label: "IPAM Subnet Prefix"
+      description: "The Subnet prefix to use for the managed network. For most users this is same as the bridge subnet prefix. Ex: 16 if using 10.42.0.1/16 for bridge subnet."
+      type: int
+      default: 16
+      required: true
+    - variable: "RANCHER_DEBUG"
+      label: "Enable Debug Logs"
+      description: "This will enable very verbose debug logs."
+      type: "boolean"
+      default: "false"
+      required: true
+    - variable: "RANCHER_HAIRPIN_MODE"
+      label: "Enable Hairpin mode"
+      description: "If this is enabled, Promiscuous mode needs to be disabled."
+      type: "boolean"
+      default: "false"
+      required: true
+    - variable: "RANCHER_PROMISCUOUS_MODE"
+      label: "Enable Promiscuous mode on the bridge"
+      description: "If this is enabled, Hairpin mode needs to be disabled."
+      type: "boolean"
+      default: "true"
+      required: true
+    - variable: "HOST_PORTS"
+      label: "Enable Host Ports"
+      description: "Flag to enable/disable publishing the ports on the hosts"
+      type: "boolean"
+      default: "true"
+      required: true

--- a/infra-templates/ipsec/config.yml
+++ b/infra-templates/ipsec/config.yml
@@ -1,5 +1,5 @@
 name: Rancher IPsec
-version: 0.1.2
+version: 0.1.3
 category: Networking
 labels:
   io.rancher.certified: rancher

--- a/infra-templates/vxlan/11/README.md
+++ b/infra-templates/vxlan/11/README.md
@@ -1,0 +1,36 @@
+## VXLAN Networking
+
+Rancher networking plugin using VXLAN overlay.
+
+### Open Ports
+
+Traffic to and from hosts requires UDP port `4789` to be open.
+
+#### Usage
+
+##### Configuration options
+* `RANCHER_DEBUG`
+
+###### [cni-driver]
+
+* `DOCKER_BRIDGE`
+* `MTU`
+* `SUBNET`
+* `SUBNET_PREFIX`
+* `RANCHER_HAIRPIN_MODE`
+* `RANCHER_PROMISCUOUS_MODE`
+* `HOST_PORTS`
+
+#### Changelog
+
+##### 0.1.3
+
+Add support for changing the IPAM subnet prefix size.
+
+##### 0.1.2
+
+The earlier version of this stack would cause a traffic disruption during upgrades, this version address to solve this problem. Also this version removes the `cni-driver` service as a sidekick of the `vxlan` container and makes it standalone.
+
+###### [rancher/net:v0.11.4]
+* This image has improved the programming logic for VXLAN to handle upgrade/restart scenarios gracefully without any traffic disruption.
+

--- a/infra-templates/vxlan/11/docker-compose.yml.tpl
+++ b/infra-templates/vxlan/11/docker-compose.yml.tpl
@@ -1,0 +1,87 @@
+version: '2'
+services:
+  vxlan:
+    # IMPORTANT!!!! DO NOT CHANGE VERSION ON UPGRADE
+    image: rancher/net:holder
+    command: sh -c "echo Refer to router sidekick for logs; mkfifo f; exec cat f"
+    network_mode: vxlan
+    ports:
+      - 4789:4789/udp
+    labels:
+      io.rancher.sidekicks: router
+      io.rancher.scheduler.global: 'true'
+      io.rancher.cni.link_mtu_overhead: '0'
+      io.rancher.internal.service.vxlan: 'true'
+      io.rancher.service.selector.link: io.rancher.internal.service.vxlan=true
+      io.rancher.network.macsync: 'true'
+      io.rancher.network.arpsync: 'true'
+    logging:
+      driver: json-file
+      options:
+        max-size: 25m
+        max-file: '2'
+  router:
+    cap_add:
+      - NET_ADMIN
+    image: rancher/net:v0.11.4
+    network_mode: container:vxlan
+    environment:
+      RANCHER_DEBUG: '${RANCHER_DEBUG}'
+    command: start-vxlan.sh
+    logging:
+      driver: json-file
+      options:
+        max-size: 25m
+        max-file: '2'
+    sysctls:
+      net.ipv4.conf.all.send_redirects: '0'
+      net.ipv4.conf.default.send_redirects: '0'
+      net.ipv4.conf.eth0.send_redirects: '0'
+  cni-driver:
+    privileged: true
+    image: rancher/net:v0.11.4
+    command: sh -c "touch /var/log/rancher-cni.log && exec tail ---disable-inotify -F /var/log/rancher-cni.log"
+    network_mode: host
+    pid: host
+    labels:
+      io.rancher.scheduler.global: 'true'
+      io.rancher.network.cni.binary: 'rancher-bridge'
+      io.rancher.container.dns: 'true'
+    logging:
+      driver: json-file
+      options:
+        max-size: 25m
+        max-file: '2'
+    network_driver:
+      name: Rancher VXLAN
+      default_network:
+        name: vxlan
+        host_ports: {{ .Values.HOST_PORTS }}
+        subnets:
+        - network_address: $SUBNET
+        dns:
+        - 169.254.169.250
+        dns_search:
+        - rancher.internal
+      cni_config:
+        '10-rancher-vxlan.conf':
+          name: rancher-cni-network
+          type: rancher-bridge
+          bridge: $DOCKER_BRIDGE
+          bridgeSubnet: $SUBNET
+          logToFile: /var/log/rancher-cni.log
+          isDebugLevel: ${RANCHER_DEBUG}
+          isDefaultGateway: true
+          hairpinMode: true
+          hostNat: true
+          hairpinMode: {{  .Values.RANCHER_HAIRPIN_MODE }}
+          promiscMode: {{ .Values.RANCHER_PROMISCUOUS_MODE }}
+          mtu: ${MTU}
+          linkMTUOverhead: 50
+          ipam:
+            type: rancher-cni-ipam
+            subnetPrefixSize: /{{ .Values.SUBNET_PREFIX }}
+            logToFile: /var/log/rancher-cni.log
+            isDebugLevel: ${RANCHER_DEBUG}
+            routes:
+              - dst: 169.254.169.250/32

--- a/infra-templates/vxlan/11/rancher-compose.yml
+++ b/infra-templates/vxlan/11/rancher-compose.yml
@@ -1,0 +1,53 @@
+.catalog:
+  name: "Rancher VXLAN"
+  version: "v0.1.3"
+  minimum_rancher_version: v1.6.3-rc1
+  questions:
+    - variable: "DOCKER_BRIDGE"
+      label: "Docker Bridge"
+      description: "Name of Docker Bridge. Default is `docker0`"
+      type: "string"
+      default: "docker0"
+      required: true
+    - variable: MTU
+      label: "MTU for the network"
+      description: "Adjust the MTU for the network, according to your needs. Ex: GCE(1460), AWS(1500), etc"
+      required: true
+      default: 1500
+      type: int
+    - variable: "SUBNET"
+      label: "Subnet"
+      description: "The subnet to use for the managed network."
+      type: "string"
+      default: '10.42.0.0/16'
+      required: true
+    - variable: "SUBNET_PREFIX"
+      label: "IPAM Subnet Prefix"
+      description: "The Subnet prefix to use for the managed network. For most users this is same as the bridge subnet prefix. Ex: 16 if using 10.42.0.1/16 for bridge subnet."
+      type: int
+      default: 16
+      required: true
+    - variable: "RANCHER_DEBUG"
+      label: "Enable Debug Logs"
+      description: "This will enable very verbose debug logs."
+      type: "boolean"
+      default: "false"
+      required: true
+    - variable: "RANCHER_HAIRPIN_MODE"
+      label: "Enable Hairpin mode"
+      description: "If this is enabled, Promiscuous mode needs to be disabled."
+      type: "boolean"
+      default: "false"
+      required: true
+    - variable: "RANCHER_PROMISCUOUS_MODE"
+      label: "Enable Promiscuous mode on the bridge"
+      description: "If this is enabled, Hairpin mode needs to be disabled."
+      type: "boolean"
+      default: "true"
+      required: true
+    - variable: "HOST_PORTS"
+      label: "Enable Host Ports"
+      description: "Flag to enable/disable publishing the ports on the hosts"
+      type: "boolean"
+      default: "true"
+      required: true

--- a/infra-templates/vxlan/config.yml
+++ b/infra-templates/vxlan/config.yml
@@ -1,7 +1,7 @@
 name: Rancher VXLAN
 description: |
   Rancher Networking plugin using VXLAN overlay.
-version: v0.1.2
+version: v0.1.3
 category: Networking
 labels:
   io.rancher.certified: rancher


### PR DESCRIPTION
This PR is intended to replace #738 with a clean history based off of the current [rancher/rancher-catalog:v1.6-development](https://github.com/rancher/rancher-catalog/tree/v1.6-development) branch.