### PR TITLE
Fix the scheduler version field

### DIFF
--- a/infra-templates/scheduler/8/rancher-compose.yml
+++ b/infra-templates/scheduler/8/rancher-compose.yml
@@ -1,7 +1,7 @@
 .catalog:
     name: Scheduler
     description: A resource based scheduler plugin for Rancher.
-    version: v0.6.2
+    version: v0.8.2
     minimum_rancher_version: v1.6.1-rc1
     questions:
         - variable: "RANCHER_DEBUG"


### PR DESCRIPTION
It looks like when the v0.8.2 template was created the catalog metadata didn't get updated to match. 