### PR TITLE
Upgrading ipsec to rancher/net:v0.11.5

### DIFF
--- a/infra-templates/ipsec/10/README.md
+++ b/infra-templates/ipsec/10/README.md
@@ -10,7 +10,8 @@ Traffic to and from hosts require UDP ports `500` and `4500` to be open.
 
 This version removes the `cni-driver` service as a sidekick of the `ipsec` service and makes it standalone.
 
-#### Router and CNI Driver [rancher/net:v0.11.4]
+#### Router and CNI Driver [rancher/net:v0.11.5]
+* Fixed an issue where tunnels were getting estabilished for stopped ipsec containers.
 * Fixed an issue where custom subnets were forcing `/16`
 
 ### Configuration options

--- a/infra-templates/ipsec/10/docker-compose.yml.tpl
+++ b/infra-templates/ipsec/10/docker-compose.yml.tpl
@@ -17,7 +17,7 @@ services:
   router:
     cap_add:
       - NET_ADMIN
-    image: rancher/net:v0.11.4
+    image: rancher/net:v0.11.5
     network_mode: container:ipsec
     environment:
       RANCHER_DEBUG: '${RANCHER_DEBUG}'
@@ -36,7 +36,7 @@ services:
       net.ipv4.xfrm4_gc_thresh: '2147483647'
   cni-driver:
     privileged: true
-    image: rancher/net:v0.11.4
+    image: rancher/net:v0.11.5
     command: sh -c "touch /var/log/rancher-cni.log && exec tail ---disable-inotify -F /var/log/rancher-cni.log"
     network_mode: host
     pid: host


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/9389
This address the problem of creating ipsec tunnels incorrectly to stopped containers.