### PR TITLE
Updating vxlan image to rancher/net:v0.11.5

### DIFF
--- a/infra-templates/vxlan/10/README.md
+++ b/infra-templates/vxlan/10/README.md
@@ -10,7 +10,8 @@ Traffic to and from hosts requires UDP port `4789` to be open.
 
 The earlier version of this stack would cause a traffic disruption during upgrades, this version address to solve this problem. Also this version removes the `cni-driver` service as a sidekick of the `vxlan` container and makes it standalone.
 
-#### Router and CNI Driver [rancher/net:v0.11.4]
+#### Router and CNI Driver [rancher/net:v0.11.5]
+* Addresses issue where stopped containers were considered as peers.
 * This image has improved the programming logic for VXLAN to handle upgrade/restart scenarios gracefully without any traffic disruption.
 * Fixed an issue where custom subnets were forcing `/16`
 

--- a/infra-templates/vxlan/10/docker-compose.yml.tpl
+++ b/infra-templates/vxlan/10/docker-compose.yml.tpl
@@ -23,7 +23,7 @@ services:
   router:
     cap_add:
       - NET_ADMIN
-    image: rancher/net:v0.11.4
+    image: rancher/net:v0.11.5
     network_mode: container:vxlan
     environment:
       RANCHER_DEBUG: '${RANCHER_DEBUG}'
@@ -39,7 +39,7 @@ services:
       net.ipv4.conf.eth0.send_redirects: '0'
   cni-driver:
     privileged: true
-    image: rancher/net:v0.11.4
+    image: rancher/net:v0.11.5
     command: sh -c "touch /var/log/rancher-cni.log && exec tail ---disable-inotify -F /var/log/rancher-cni.log"
     network_mode: host
     pid: host


### PR DESCRIPTION
Consider only running/starting containers as peers.