### PR TITLE
Upgrading to rancher/network-manager:v0.7.7

### DIFF
--- a/infra-templates/network-services/22/README.md
+++ b/infra-templates/network-services/22/README.md
@@ -10,8 +10,8 @@ This stack provides the following services:
 
 Default timeout for internal Rancher DNS was updated from 10 seconds to 1 second.
 
-#### Network Manager [rancher/network-manager:v0.7.6]
-* Fixes the arpsync logic to take action on only running and starting containers.
+#### Network Manager [rancher/network-manager:v0.7.7]
+* Fixes the conntrack, arpsync logic to take action on only running and starting containers.
 * Fixes the logic of figuring out local networks in an environment to support different CNI plugins.
 
 ### Configuration Options

--- a/infra-templates/network-services/22/docker-compose.yml
+++ b/infra-templates/network-services/22/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   network-manager:
-    image: rancher/network-manager:v0.7.6
+    image: rancher/network-manager:v0.7.7
     privileged: true
     network_mode: host
     pid: host


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/9519

Notes:
- build containers `map[hostIP:hostPort/protocol]` but only for running/starting containers
- Read conntrack entries, build the lookup key based on the info in the entry.
- lookup the map built previously. If hit, check if the conntrack entry has correct ip address of container. else don't do anything.

So the case of stopping containers losing traffic will happen when there is a new starting/running container with a different managed IP and with the same expose port on the same host. (This basically logically not possible)

This logic is mainly for upgraded containers .... An old container has IP: `o.o.o.o` with expose port say 4500/tcp. When it's upgraded a new container with IP: `n.n.n.n`, the old conntrack entry which was pointing to the old IP need to be flushed.