### PR TITLE
DNS/Metadata fixes

### DIFF
--- a/infra-templates/network-services/23/README.md
+++ b/infra-templates/network-services/23/README.md
@@ -11,6 +11,9 @@ This stack provides the following services:
 #### Metadata [rancher/rancher-metadata:v0.9.3]
 * Fixes around decoding delta when reading from file and event stream
 
+#### DNS [rancher/dns:v0.15.1]
+* Uses a fixed listen address of 169.254.169.250, instead of all available IP addresses.
+
 ### Configuration Options
 
 #### dns

--- a/infra-templates/network-services/23/docker-compose.yml
+++ b/infra-templates/network-services/23/docker-compose.yml
@@ -41,10 +41,14 @@ services:
       options:
         max-size: 25m
         max-file: '2'
+    sysctls:
+      net.ipv4.conf.all.send_redirects: '0'
+      net.ipv4.conf.default.send_redirects: '0'
+      net.ipv4.conf.eth0.send_redirects: '0'
   dns:
     image: rancher/dns:v0.15.1
     network_mode: container:metadata
-    command: rancher-dns --metadata-server=localhost --answers=/etc/rancher-dns/answers.json --recurser-timeout ${DNS_RECURSER_TIMEOUT} --ttl ${TTL}
+    command: rancher-dns --listen 169.254.169.250:53 --metadata-server=localhost --answers=/etc/rancher-dns/answers.json --recurser-timeout ${DNS_RECURSER_TIMEOUT} --ttl ${TTL}
     labels:
       io.rancher.scheduler.global: 'true'
     logging:


### PR DESCRIPTION
This PR addresses two issues:
* https://github.com/rancher/rancher/issues/9547
* https://github.com/rancher/rancher/issues/9548

Problem with 9547: Since the DNS server is listening on all IP addresses available on the interface, the DNS reply packet is not using the IP: `169.254.169.250`.
Fix for 9547: Just listen on IP: `169.254.169.250`

9548: Disable ICMP redirects. Similar to https://github.com/rancher/rancher/issues/8203

https://github.com/rancher/rancher/issues/8527