### PR TITLE
v1.7.2-rancher6 and startup order change

### DIFF
--- a/infra-templates/k8s/31/docker-compose.yml.tpl
+++ b/infra-templates/k8s/31/docker-compose.yml.tpl
@@ -31,7 +31,7 @@ kubelet:
         {{- range $i, $elem := splitPreserveQuotes .Values.ADDITIONAL_KUBELET_FLAGS }}
         - {{ $elem }}
         {{- end }}
-    image: rancher/k8s:v1.7.2-rancher5
+    image: rancher/k8s:v1.7.2-rancher6
     volumes:
         - /run:/run
         - /var/run:/var/run
@@ -49,6 +49,7 @@ kubelet:
     privileged: true
     links:
         - kubernetes
+        - rancher-cloud-controller-manager
 
 {{- if eq .Values.CONSTRAINT_TYPE "required" }}
 kubelet-unschedulable:
@@ -83,7 +84,7 @@ kubelet-unschedulable:
         {{- range $i, $elem := splitPreserveQuotes .Values.ADDITIONAL_KUBELET_FLAGS }}
         - {{ $elem }}
         {{- end }}
-    image: rancher/k8s:v1.7.2-rancher5
+    image: rancher/k8s:v1.7.2-rancher6
     volumes:
         - /run:/run
         - /var/run:/var/run
@@ -109,7 +110,7 @@ proxy:
         - --kubeconfig=/etc/kubernetes/ssl/kubeconfig
         - --v=2
         - --healthz-bind-address=0.0.0.0
-    image: rancher/k8s:v1.7.2-rancher5
+    image: rancher/k8s:v1.7.2-rancher6
     labels:
         io.rancher.container.dns: "true"
         io.rancher.scheduler.global: "true"
@@ -180,7 +181,7 @@ kubernetes:
         {{- end }}
     environment:
         KUBERNETES_URL: https://kubernetes.kubernetes.rancher.internal:6443
-    image: rancher/k8s:v1.7.2-rancher5
+    image: rancher/k8s:v1.7.2-rancher6
     links:
         - etcd
 
@@ -234,7 +235,7 @@ scheduler:
         - kube-scheduler
         - --kubeconfig=/etc/kubernetes/ssl/kubeconfig
         - --address=0.0.0.0
-    image: rancher/k8s:v1.7.2-rancher5
+    image: rancher/k8s:v1.7.2-rancher6
     labels:
         {{- if eq .Values.CONSTRAINT_TYPE "required" }}
         io.rancher.scheduler.affinity:host_label: orchestration=true
@@ -256,7 +257,7 @@ controller-manager:
         - --address=0.0.0.0
         - --root-ca-file=/etc/kubernetes/ssl/ca.pem
         - --service-account-private-key-file=/etc/kubernetes/ssl/key.pem
-    image: rancher/k8s:v1.7.2-rancher5
+    image: rancher/k8s:v1.7.2-rancher6
     labels:
         {{- if eq .Values.CONSTRAINT_TYPE "required" }}
         io.rancher.scheduler.affinity:host_label: orchestration=true
@@ -273,7 +274,7 @@ rancher-cloud-controller-manager:
         - --cloud-provider=rancher
         - --address=0.0.0.0
         - --service-account-private-key-file=/etc/kubernetes/ssl/key.pem
-    image: rancher/k8s:v1.7.2-rancher5
+    image: rancher/k8s:v1.7.2-rancher6
     labels:
         {{- if eq .Values.CONSTRAINT_TYPE "required" }}
         io.rancher.scheduler.affinity:host_label: orchestration=true
@@ -351,7 +352,7 @@ rancher-kubernetes-auth:
 
 {{- if eq .Values.ENABLE_ADDONS "true" }}
 addon-starter:
-    image: rancher/k8s:v1.7.2-rancher5
+    image: rancher/k8s:v1.7.2-rancher6
     labels:
         {{- if eq .Values.CONSTRAINT_TYPE "required" }}
         io.rancher.scheduler.affinity:host_label: orchestration=true

--- a/infra-templates/k8s/31/rancher-compose.yml
+++ b/infra-templates/k8s/31/rancher-compose.yml
@@ -1,6 +1,6 @@
 .catalog:
   name: Kubernetes
-  version: v1.7.2-rancher5-1
+  version: v1.7.2-rancher6
   description: Rancher Kubernetes service
   minimum_rancher_version: v1.6.6-rc1
   questions:

--- a/infra-templates/k8s/config.yml
+++ b/infra-templates/k8s/config.yml
@@ -1,5 +1,5 @@
 name: Kubernetes
-version: v1.7.2-rancher5-1
+version: v1.7.2-rancher6
 category: Orchestration
 labels:
   io.rancher.certified: rancher


### PR DESCRIPTION
@joshwget I've put internalIp address population back hence the k8s/rancher-controller-manager update. Put links to rancher-cloud-controller-manager to kubelet service to ensure that the rancher-cloud-controller-manager starts up first.