### PR TITLE
Update scheduler command

### DIFF
--- a/infra-templates/scheduler/9/docker-compose.yml
+++ b/infra-templates/scheduler/9/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '2'
+services:
+  scheduler:
+    image: rancher/scheduler:v0.8.2
+    command: scheduler --metadata-address 169.254.169.250
+    environment:
+        RANCHER_DEBUG: '${RANCHER_DEBUG}'
+    labels:
+        io.rancher.container.create_agent: "true"
+        io.rancher.container.agent_service.scheduling: "true"
+    logging:
+      driver: json-file
+      options:
+        max-size: 25m
+        max-file: '2'

--- a/infra-templates/scheduler/9/rancher-compose.yml
+++ b/infra-templates/scheduler/9/rancher-compose.yml
@@ -1,0 +1,23 @@
+.catalog:
+    name: Scheduler
+    description: A resource based scheduler plugin for Rancher.
+    version: v0.6.3
+    minimum_rancher_version: v1.6.1-rc1
+    questions:
+        - variable: "RANCHER_DEBUG"
+          label: "Enable Debug Logs"
+          description: "This will enable very verbose debug logs."
+          type: "boolean"
+          default: "false"
+          required: true
+
+scheduler:
+    health_check:
+        request_line: GET /healthcheck HTTP/1.0
+        port: 80
+        interval: 2000
+        initializing_timeout: 10000
+        reinitializing_timeout: 10000
+        response_timeout: 2000
+        unhealthy_threshold: 3
+        healthy_threshold: 2

--- a/infra-templates/scheduler/config.yml
+++ b/infra-templates/scheduler/config.yml
@@ -1,5 +1,5 @@
 name: Scheduler
-version: v0.6.2
+version: v0.6.3
 category: Framework
 description: A resource based scheduler plugin for Rancher.
 projectURL: https://github.com/rancher/scheduler


### PR DESCRIPTION
The only change between this and v0.6.2 is the addition of --metadata-address 169.254.169.250 to the scheduler service command. This is so that it can find Rancher Metadata without the need for DNS to be responding.