### PR TITLE
Bump etcd version to v2.3.7-14

### DIFF
--- a/infra-templates/k8s/30/docker-compose.yml.tpl
+++ b/infra-templates/k8s/30/docker-compose.yml.tpl
@@ -105,7 +105,7 @@ proxy:
         - kubernetes
 
 etcd:
-    image: rancher/etcd:v2.3.7-13
+    image: rancher/etcd:v2.3.7-14
     labels:
         {{- if eq .Values.CONSTRAINT_TYPE "required" }}
         io.rancher.scheduler.affinity:host_label: etcd=true

--- a/infra-templates/k8s/31/docker-compose.yml.tpl
+++ b/infra-templates/k8s/31/docker-compose.yml.tpl
@@ -113,7 +113,7 @@ proxy:
         - kubernetes
 
 etcd:
-    image: rancher/etcd:v2.3.7-13
+    image: rancher/etcd:v2.3.7-14
     labels:
         {{- if eq .Values.CONSTRAINT_TYPE "required" }}
         io.rancher.scheduler.affinity:host_label: etcd=true


### PR DESCRIPTION
After removing a member from the cluster, waits until a new leader is elected before attempting to add any new members.