### PR TITLE
start kubelet with rancher container dns priority None

### DIFF
--- a/infra-templates/k8s/33/docker-compose.yml.tpl
+++ b/infra-templates/k8s/33/docker-compose.yml.tpl
@@ -1,6 +1,7 @@
 kubelet:
     labels:
         io.rancher.container.dns: "true"
+        io.rancher.container.dns.priority: "None"
         io.rancher.container.create_agent: "true"
         io.rancher.container.agent.role: environmentAdmin
         io.rancher.scheduler.global: "true"

--- a/infra-templates/k8s/34/docker-compose.yml.tpl
+++ b/infra-templates/k8s/34/docker-compose.yml.tpl
@@ -3,6 +3,7 @@ services:
   kubelet:
     labels:
       io.rancher.container.dns: "true"
+      io.rancher.container.dns.priority: "None"
       io.rancher.container.create_agent: "true"
       io.rancher.container.agent.role: environmentAdmin
       io.rancher.scheduler.global: "true"


### PR DESCRIPTION
[rancher/rancher#9303](https://github.com/rancher/rancher/issues/9303)

This will allow kubelet to not inherit rancher internal domains. 