### PR TITLE
Changed cpu period and cpu quota for metadata container

### DIFF
--- a/infra-templates/network-services/25/rancher-compose.yml
+++ b/infra-templates/network-services/25/rancher-compose.yml
@@ -19,13 +19,13 @@
       label: CPU scheduler period
       description: Sets the period of CPUs to limit the metadata container’s CPU usage
       required: true
-      default: 100000
+      default: 400000
       type: int
     - variable: CPU_QUOTA
       label: CPU quota on the metadata container
       description: Sets the CPU quota on the metadata container
       required: true
-      default: 70000
+      default: 200000
       type: int
     - variable: RELOAD_INTERVAL_LIMIT
       label: Metadata reload interval limit


### PR DESCRIPTION
Reduced the amount of metadata cpu_quota to 50%; also reduced the fraction for both cpu_quota and cpu_shares

This would result in the container getting 50% CPU run-time every 10ms. 

@ibuildthecloud need your input on it - are you ok with the % as well as the fraction (min is 1000=1milisecond for both cpu_quota and cpu_period)