### PR TITLE
Update admission controllers for k8s v1.9

### DIFF
--- a/infra-templates/k8s/40/docker-compose.yml.tpl
+++ b/infra-templates/k8s/40/docker-compose.yml.tpl
@@ -209,7 +209,7 @@ kubernetes:
         - --cloud-config=/etc/kubernetes/cloud-provider-config
         {{- end }}
         - --allow_privileged=true
-        - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,DefaultStorageClass,ResourceQuota,DefaultTolerationSeconds
+        - --admission-control=$ADMISSION_CONTROLLERS
         - --client-ca-file=/etc/kubernetes/ssl/ca.pem
         - --tls-cert-file=/etc/kubernetes/ssl/cert.pem
         - --tls-private-key-file=/etc/kubernetes/ssl/key.pem

--- a/infra-templates/k8s/40/rancher-compose.yml
+++ b/infra-templates/k8s/40/rancher-compose.yml
@@ -139,6 +139,12 @@
     required: false
     default: false
     type: boolean
+  - variable: ADMISSION_CONTROLLERS
+    description: Admission controllers intercept requests to the Kubernetes API server after they are authenticated and authorized. Admission controllers validate and/or mutate objects in the requests before they are persisted, and they are processed in order.
+    label: Kubernetes Admission controllers
+    required: false
+    default:  NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,DefaultStorageClass,DefaultTolerationSeconds,ResourceQuota
+    type: string
   - variable: SERVICE_CLUSTER_CIDR
     label: Service Cluster IP CIDR
     description: A CIDR notation IP range from which to assign service cluster IPs. This must not overlap with any IP ranges assigned to the cluster pod IP CIDR (10.42.0.0/16).


### PR DESCRIPTION
- Add [updated admission controllers for 1.9](https://kubernetes.io/docs/admin/admission-controllers/#is-there-a-recommended-set-of-admission-controllers-to-use) except for:
   - `MutatingAdmissionWebhook`
   - `ValidatingAdmissionWebhook`

- Make admission controllers configurable. 