### PR TITLE
Update docker-compose.yml.tpl of ECR

### DIFF
--- a/infra-templates/container-crontab/3/README.md
+++ b/infra-templates/container-crontab/3/README.md
@@ -1,0 +1,24 @@
+## Rancher Container Crontab
+Starts, stops or restarts containers in your environment
+
+### Usage
+
+This service deploys globally, and listens on the Docker socket for start/create/destroy events. 
+If the container is part of a service, container-crontab will verify that the service is in an
+`active` state. If it isn't the job will be ignored. Keep in mind that services that are waiting
+for upgrade confirmation, will not have cron jobs run.
+To automatically have your container started every 5 minutes, add the label:
+
+`cron.schedule="0 0-59/5 * * * ?"`
+
+To your container. See [robfig/cron](https://godoc.org/github.com/robfig/cron) docs for schedule rules.
+
+To override the default action `start` you can apply the label:
+
+`cron.action` to either `stop` or `restart`
+
+The default restart_timeout is `10 seconds` to override apply the label:
+
+`cron.restart_timeout` in seconds
+
+_Note_ *the restart_timeout also applys to `stop` action.

--- a/infra-templates/container-crontab/3/docker-compose.yml
+++ b/infra-templates/container-crontab/3/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '2'
+services:
+  container-crontab:
+    image: rancher/container-crontab:v0.3.0
+    privileged: true
+    environment:
+      DOCKER_API_VERSION: 1.24
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    labels:
+      io.rancher.scheduler.global: true
+      io.rancher.container.hostname_override: container_name
+    command: container-crontab {{- if eq .Values.debug "true" }} -d {{- end }} --rancher-mode{{- if eq .Values.metrics "true" }} --metrics{{- end }}

--- a/infra-templates/container-crontab/3/docker-compose.yml
+++ b/infra-templates/container-crontab/3/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   container-crontab:
-    image: rancher/container-crontab:v0.3.0
+    image: rancher/container-crontab:v0.4.0
     privileged: true
     environment:
       DOCKER_API_VERSION: 1.24

--- a/infra-templates/container-crontab/3/rancher-compose.yml
+++ b/infra-templates/container-crontab/3/rancher-compose.yml
@@ -1,0 +1,23 @@
+.catalog:
+  name: "Rancher Container Crontab"
+  version: "v0.3.0"
+  description: "Service that will start, stop or restart containers"
+  minimum_rancher_version: v1.6.0
+  questions:
+    - variable: metrics
+      type: enum
+      label: Enable Metrics Endpoint
+      description: |
+        <container>:9191/metrics will be available for Prometheus scraping.
+      default: false
+      options:
+        - true
+        - false
+    - variable: debug
+      type: enum
+      default: false
+      options:
+        - true
+        - false
+      label: Enable Debug
+      

--- a/infra-templates/container-crontab/3/rancher-compose.yml
+++ b/infra-templates/container-crontab/3/rancher-compose.yml
@@ -1,6 +1,6 @@
 .catalog:
   name: "Rancher Container Crontab"
-  version: "v0.3.0"
+  version: "v0.4.0"
   description: "Service that will start, stop or restart containers"
   minimum_rancher_version: v1.6.0
   questions:

--- a/infra-templates/container-crontab/config.yml
+++ b/infra-templates/container-crontab/config.yml
@@ -1,7 +1,7 @@
 name: Rancher Container Cron
 description: |
   Rancher Container Crontab starts, stops or restarts containers 
-version: v0.3.0
+version: v0.4.0
 category: Framework
 labels:
   io.rancher.orchestration.supported: 'cattle'

--- a/infra-templates/ebs/4/rancher-compose.yml
+++ b/infra-templates/ebs/4/rancher-compose.yml
@@ -4,6 +4,7 @@
   description: |
     Docker volume plugin for EBS
   minimum_rancher_version: v1.6.11-rc1
+  maximum_rancher_version: v1.6.14
   questions:
   - variable: AWS_ACCESS_KEY_ID
     label: AWS Access Key

--- a/infra-templates/ebs/5/docker-compose.yml
+++ b/infra-templates/ebs/5/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '2'
+services:
+  ebs-driver:
+    privileged: true
+    network_mode: host
+    image: rancher/storage-ebs:v0.8.11
+    labels:
+      io.rancher.scheduler.global: 'true'
+      io.rancher.container.create_agent: 'true'
+      io.rancher.container.agent.role: environment
+    environment:
+      AWS_SECRET_ACCESS_KEY: '${AWS_SECRET_ACCESS_KEY}'
+      AWS_ACCESS_KEY_ID: '${AWS_ACCESS_KEY_ID}'
+      RANCHER_DEBUG: '${RANCHER_DEBUG}'
+    volumes:
+    - /run:/run
+    - /var/run:/var/run
+    - /dev:/host/dev
+    - /var/lib/rancher/volumes:/var/lib/rancher/volumes:shared
+    logging:
+      driver: json-file
+      options:
+        max-size: 25m
+        max-file: '2'

--- a/infra-templates/ebs/5/docker-compose.yml
+++ b/infra-templates/ebs/5/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   ebs-driver:
     privileged: true
     network_mode: host
-    image: rancher/storage-ebs:v0.8.11
+    image: rancher/storage-ebs:v0.9.0
     labels:
       io.rancher.scheduler.global: 'true'
       io.rancher.container.create_agent: 'true'

--- a/infra-templates/ebs/5/rancher-compose.yml
+++ b/infra-templates/ebs/5/rancher-compose.yml
@@ -1,0 +1,28 @@
+.catalog:
+  name: "Rancher EBS"
+  version: "0.4.0"
+  description: |
+    Docker volume plugin for EBS
+  minimum_rancher_version: v1.6.11-rc1
+  questions:
+  - variable: AWS_ACCESS_KEY_ID
+    label: AWS Access Key
+    type: string
+    description: Optional if using IAM Profile
+  - variable: AWS_SECRET_ACCESS_KEY
+    label: AWS Secret Key
+    type: password
+    description: Optional if using IAM Profile
+  - variable: RANCHER_DEBUG
+    label: Debug Mode
+    type: enum
+    description: Enable or disable verbose logging
+    default: false
+    options:
+    - true
+    - false
+ebs-driver:
+  storage_driver:
+    name: rancher-ebs
+    scope: environment
+    volume_access_mode: singleHostRW

--- a/infra-templates/ebs/5/rancher-compose.yml
+++ b/infra-templates/ebs/5/rancher-compose.yml
@@ -1,9 +1,9 @@
 .catalog:
   name: "Rancher EBS"
-  version: "0.4.0"
+  version: "0.5.0"
   description: |
     Docker volume plugin for EBS
-  minimum_rancher_version: v1.6.11-rc1
+  minimum_rancher_version: v1.6.15-rc1
   questions:
   - variable: AWS_ACCESS_KEY_ID
     label: AWS Access Key

--- a/infra-templates/ebs/config.yml
+++ b/infra-templates/ebs/config.yml
@@ -1,7 +1,7 @@
 name: Rancher EBS
 description: |
   Docker volume plugin for Amazon EBS
-version: 0.4.0
+version: 0.5.0
 category: Storage
 labels:
   io.rancher.certified: rancher

--- a/infra-templates/ecr/1/docker-compose.yml.tpl
+++ b/infra-templates/ecr/1/docker-compose.yml.tpl
@@ -1,10 +1,10 @@
 ecr-updater:
   environment:
-    AWS_ACCESS_KEY_ID: ${aws_access_key_id}
-    AWS_SECRET_ACCESS_KEY: ${aws_secret_access_key}
-    AWS_REGION: ${aws_region}
-    AUTO_CREATE: ${auto_create}
-    LOG_LEVEL: ${log_level}
+    AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+    AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+    AWS_REGION: ${AWS_REGION}
+    AUTO_CREATE: ${AUTO_CREATE}
+    LOG_LEVEL: ${LOG_LEVEL}
     {{- if eq .Values.registry_in_which_environment "other" }}
     CATTLE_URL: ${environment_api_endpoint}
     CATTLE_ACCESS_KEY: ${environment_api_access_key}

--- a/infra-templates/ipsec/15/rancher-compose.yml
+++ b/infra-templates/ipsec/15/rancher-compose.yml
@@ -2,6 +2,7 @@
   name: "Rancher IPsec"
   version: "0.2.2"
   minimum_rancher_version: v1.6.13-rc1
+  maximum_rancher_version: v1.6.14
   questions:
     - variable: "DOCKER_BRIDGE"
       label: "Docker Bridge"

--- a/infra-templates/ipsec/16/README.md
+++ b/infra-templates/ipsec/16/README.md
@@ -1,0 +1,32 @@
+## IPSec Networking
+
+Rancher networking plugin using IPsec.
+
+### Open Ports
+
+Traffic to and from hosts require UDP ports `500` and `4500` to be open.
+
+### Changelog - 0.2.2
+
+#### Router and CNI Driver [rancher/net:v0.13.7]
+* Introduced connectivity check for ipsec.
+* Fixed an issue where scheduler IPs could be picked up as the IP for the ipsec service for ports `500` and `4500`, which would cause cross host communication to no longer work for that host
+
+### Configuration options
+* `RANCHER_DEBUG`
+
+#### ipsec
+
+* `IPSEC_REPLAY_WINDOW_SIZE`
+* `IPSEC_IKE_SA_REKEY_INTERVAL`
+* `IPSEC_CHILD_SA_REKEY_INTERVAL`
+
+#### cni-driver
+
+* `DOCKER_BRIDGE`
+* `MTU`
+* `SUBNET`
+* `RANCHER_HAIRPIN_MODE`
+* `RANCHER_PROMISCUOUS_MODE`
+* `HOST_PORTS`
+* `SUBNET_PREFIX`

--- a/infra-templates/ipsec/16/README.md
+++ b/infra-templates/ipsec/16/README.md
@@ -8,7 +8,7 @@ Traffic to and from hosts require UDP ports `500` and `4500` to be open.
 
 ### Changelog - 0.2.3
 
-#### Router, CNI Driver, Connectivity Check [rancher/net:v0.13.8]
+#### Router, CNI Driver, Connectivity Check [rancher/net:v0.13.9]
 * Added support for regions
 * Reduced the logging level for ipsec
 

--- a/infra-templates/ipsec/16/README.md
+++ b/infra-templates/ipsec/16/README.md
@@ -6,11 +6,11 @@ Rancher networking plugin using IPsec.
 
 Traffic to and from hosts require UDP ports `500` and `4500` to be open.
 
-### Changelog - 0.2.2
+### Changelog - 0.2.3
 
-#### Router and CNI Driver [rancher/net:v0.13.7]
-* Introduced connectivity check for ipsec.
-* Fixed an issue where scheduler IPs could be picked up as the IP for the ipsec service for ports `500` and `4500`, which would cause cross host communication to no longer work for that host
+#### Router, CNI Driver, Connectivity Check [rancher/net:v0.13.8]
+* Added support for regions
+* Reduced the logging level for ipsec
 
 ### Configuration options
 * `RANCHER_DEBUG`
@@ -20,12 +20,15 @@ Traffic to and from hosts require UDP ports `500` and `4500` to be open.
 * `IPSEC_REPLAY_WINDOW_SIZE`
 * `IPSEC_IKE_SA_REKEY_INTERVAL`
 * `IPSEC_CHILD_SA_REKEY_INTERVAL`
+* `RANCHER_IPSEC_PSK`
 
 #### cni-driver
 
 * `DOCKER_BRIDGE`
 * `MTU`
 * `SUBNET`
+* `SUBNET_START_ADDRESS`
+* `SUBNET_END_ADDRESS`
 * `RANCHER_HAIRPIN_MODE`
 * `RANCHER_PROMISCUOUS_MODE`
 * `HOST_PORTS`

--- a/infra-templates/ipsec/16/docker-compose.yml.tpl
+++ b/infra-templates/ipsec/16/docker-compose.yml.tpl
@@ -1,0 +1,100 @@
+version: '2'
+
+{{- $netImage:="rancher/net:v0.13.7" }}
+
+services:
+  ipsec:
+    # IMPORTANT!!!! DO NOT CHANGE VERSION ON UPGRADE
+    image: rancher/net:holder
+    command: sh -c "echo Refer to router sidekick for logs; mkfifo f; exec cat f"
+    network_mode: ipsec
+    ports:
+      - 0.0.0.0:500:500/udp
+      - 0.0.0.0:4500:4500/udp
+    labels:
+      io.rancher.sidekicks: router,connectivity-check
+      io.rancher.scheduler.global: 'true'
+      io.rancher.cni.link_mtu_overhead: '0'
+      io.rancher.network.macsync: 'true'
+      io.rancher.network.arpsync: 'true'
+  router:
+    cap_add:
+      - NET_ADMIN
+    image: {{$netImage}}
+    command: start-ipsec.sh
+    network_mode: container:ipsec
+    environment:
+      RANCHER_DEBUG: '${RANCHER_DEBUG}'
+      IPSEC_REPLAY_WINDOW_SIZE: '${IPSEC_REPLAY_WINDOW_SIZE}'
+      IPSEC_IKE_SA_REKEY_INTERVAL: '${IPSEC_IKE_SA_REKEY_INTERVAL}'
+      IPSEC_CHILD_SA_REKEY_INTERVAL: '${IPSEC_CHILD_SA_REKEY_INTERVAL}'
+    labels:
+      io.rancher.container.create_agent: 'true'
+      io.rancher.container.agent_service.ipsec: 'true'
+    logging:
+      driver: json-file
+      options:
+        max-size: 25m
+        max-file: '2'
+    sysctls:
+      net.ipv4.conf.all.send_redirects: '0'
+      net.ipv4.conf.default.send_redirects: '0'
+      net.ipv4.conf.eth0.send_redirects: '0'
+      net.ipv4.xfrm4_gc_thresh: '2147483647'
+  connectivity-check:
+    image: {{$netImage}}
+    command:
+      - connectivity-check
+    environment:
+      RANCHER_DEBUG: '${RANCHER_DEBUG}'
+    network_mode: container:ipsec
+  cni-driver:
+    privileged: true
+    image: {{$netImage}}
+    command: start-cni-driver.sh
+    network_mode: host
+    pid: host
+    environment:
+      RANCHER_DEBUG: '${RANCHER_DEBUG}'
+    labels:
+      io.rancher.scheduler.global: 'true'
+      io.rancher.network.cni.binary: 'rancher-bridge'
+      io.rancher.container.dns: 'true'
+    logging:
+      driver: json-file
+      options:
+        max-size: 25m
+        max-file: '2'
+    volumes:
+    - /var/run/docker.sock:/var/run/docker.sock
+    - rancher-cni-driver:/opt/cni-driver
+    network_driver:
+      name: Rancher IPsec
+      default_network:
+        name: ipsec
+        host_ports: {{ .Values.HOST_PORTS }}
+        subnets:
+        - network_address: $SUBNET
+        dns:
+        - 169.254.169.250
+        dns_search:
+        - rancher.internal
+      cni_config:
+        '10-rancher.conf':
+          name: rancher-cni-network
+          type: rancher-bridge
+          bridge: $DOCKER_BRIDGE
+          bridgeSubnet: $SUBNET
+          logToFile: /var/log/rancher-cni.log
+          isDebugLevel: ${RANCHER_DEBUG}
+          isDefaultGateway: true
+          hostNat: true
+          hairpinMode: {{  .Values.RANCHER_HAIRPIN_MODE }}
+          promiscMode: {{ .Values.RANCHER_PROMISCUOUS_MODE }}
+          mtu: ${MTU}
+          linkMTUOverhead: 98
+          ipam:
+            type: rancher-cni-ipam
+            subnetPrefixSize: /{{ .Values.SUBNET_PREFIX }}
+            logToFile: /var/log/rancher-cni.log
+            isDebugLevel: ${RANCHER_DEBUG}

--- a/infra-templates/ipsec/16/docker-compose.yml.tpl
+++ b/infra-templates/ipsec/16/docker-compose.yml.tpl
@@ -1,6 +1,6 @@
 version: '2'
 
-{{- $netImage:="rancher/net:v0.13.8" }}
+{{- $netImage:="rancher/net:v0.13.9" }}
 
 services:
   ipsec:

--- a/infra-templates/ipsec/16/docker-compose.yml.tpl
+++ b/infra-templates/ipsec/16/docker-compose.yml.tpl
@@ -1,6 +1,6 @@
 version: '2'
 
-{{- $netImage:="rancher/net:v0.13.7" }}
+{{- $netImage:="rancher/net:v0.13.8" }}
 
 services:
   ipsec:
@@ -28,6 +28,7 @@ services:
       IPSEC_REPLAY_WINDOW_SIZE: '${IPSEC_REPLAY_WINDOW_SIZE}'
       IPSEC_IKE_SA_REKEY_INTERVAL: '${IPSEC_IKE_SA_REKEY_INTERVAL}'
       IPSEC_CHILD_SA_REKEY_INTERVAL: '${IPSEC_CHILD_SA_REKEY_INTERVAL}'
+      RANCHER_IPSEC_PSK: '${RANCHER_IPSEC_PSK}'
     labels:
       io.rancher.container.create_agent: 'true'
       io.rancher.container.agent_service.ipsec: 'true'
@@ -75,6 +76,8 @@ services:
         host_ports: {{ .Values.HOST_PORTS }}
         subnets:
         - network_address: $SUBNET
+          start_address: $SUBNET_START_ADDRESS
+          end_address: $SUBNET_END_ADDRESS
         dns:
         - 169.254.169.250
         dns_search:

--- a/infra-templates/ipsec/16/rancher-compose.yml
+++ b/infra-templates/ipsec/16/rancher-compose.yml
@@ -1,0 +1,83 @@
+.catalog:
+  name: "Rancher IPsec"
+  version: "0.2.2"
+  minimum_rancher_version: v1.6.13-rc1
+  questions:
+    - variable: "DOCKER_BRIDGE"
+      label: "Docker Bridge"
+      description: "Name of Docker Bridge. Default is `docker0`"
+      type: "string"
+      default: "docker0"
+      required: true
+    - variable: MTU
+      label: "MTU for the network"
+      description: "Adjust the MTU for the network, according to your needs. Ex: GCE(1460), AWS(1500), etc"
+      required: true
+      default: 1500
+      type: int
+    - variable: "SUBNET"
+      label: "Subnet"
+      description: "The subnet to use for the managed IPSEC network."
+      type: "string"
+      default: '10.42.0.0/16'
+      required: true
+    - variable: "SUBNET_PREFIX"
+      label: "IPAM Subnet Prefix"
+      description: "The Subnet prefix to use for the managed network. For most users this is same as the bridge subnet prefix. Ex: 16 if using 10.42.0.0/16 for bridge subnet."
+      type: int
+      default: 16
+      required: true
+    - variable: "RANCHER_DEBUG"
+      label: "Enable Debug Logs"
+      description: "This will enable very verbose debug logs."
+      type: "boolean"
+      default: "false"
+      required: true
+    - variable: "RANCHER_HAIRPIN_MODE"
+      label: "Enable Hairpin mode"
+      description: "If this is enabled, Promiscuous mode needs to be disabled."
+      type: "boolean"
+      default: "false"
+      required: true
+    - variable: "RANCHER_PROMISCUOUS_MODE"
+      label: "Enable Promiscuous mode on the bridge"
+      description: "If this is enabled, Hairpin mode needs to be disabled."
+      type: "boolean"
+      default: "true"
+      required: true
+    - variable: "HOST_PORTS"
+      label: "Enable Host Ports"
+      description: "Flag to enable/disable publishing the ports on the hosts"
+      type: "boolean"
+      default: "true"
+      required: true
+    - variable: "IPSEC_REPLAY_WINDOW_SIZE"
+      label: "IPSec Replay Window size"
+      description: "This option is helpful to adjust the replay window size"
+      type: "string"
+      default: '1024'
+      required: true
+    - variable: "IPSEC_IKE_SA_REKEY_INTERVAL"
+      label: "IPSec IKE_SA rekey interval"
+      description: "Proceed with caution; typical users will not need to change this. Incorrect values can break your Rancher installation."
+      type: "string"
+      default: '4h'
+      required: true
+    - variable: "IPSEC_CHILD_SA_REKEY_INTERVAL"
+      label: "IPSec CHILD_SA rekey time"
+      description: "Proceed with caution; typical users will not need to change this. Incorrect values can break your Rancher installation."
+      type: "string"
+      default: '1h'
+      required: true
+
+ipsec:
+  health_check:
+    request_line: GET "/connectivity" "HTTP/1.0"
+    port: 80
+    interval: 5000
+    initializing_timeout: 60000
+    reinitializing_timeout: 60000
+    response_timeout: 2000
+    healthy_threshold: 2
+    unhealthy_threshold: 3
+    strategy: none

--- a/infra-templates/ipsec/16/rancher-compose.yml
+++ b/infra-templates/ipsec/16/rancher-compose.yml
@@ -1,7 +1,7 @@
 .catalog:
   name: "Rancher IPsec"
-  version: "0.2.2"
-  minimum_rancher_version: v1.6.13-rc1
+  version: "0.2.3"
+  minimum_rancher_version: v1.6.15-rc1
   questions:
     - variable: "DOCKER_BRIDGE"
       label: "Docker Bridge"
@@ -21,6 +21,18 @@
       type: "string"
       default: '10.42.0.0/16'
       required: true
+    - variable: "SUBNET_START_ADDRESS"
+      label: "Subnet start IP Address"
+      description: "This is an advanced setting and most users will not need to use this. Incorrect values can break your Rancher installation."
+      type: "string"
+      default: ''
+      required: false
+    - variable: "SUBNET_END_ADDRESS"
+      label: "Subnet end IP Address"
+      description: "This is an advanced setting and most users will not need to use this. Incorrect values can break your Rancher installation."
+      type: "string"
+      default: ''
+      required: false
     - variable: "SUBNET_PREFIX"
       label: "IPAM Subnet Prefix"
       description: "The Subnet prefix to use for the managed network. For most users this is same as the bridge subnet prefix. Ex: 16 if using 10.42.0.0/16 for bridge subnet."
@@ -59,17 +71,22 @@
       required: true
     - variable: "IPSEC_IKE_SA_REKEY_INTERVAL"
       label: "IPSec IKE_SA rekey interval"
-      description: "Proceed with caution; typical users will not need to change this. Incorrect values can break your Rancher installation."
+      description: "This is an advanced setting and most users will not need to use this. Incorrect values can break your Rancher installation."
       type: "string"
       default: '4h'
       required: true
     - variable: "IPSEC_CHILD_SA_REKEY_INTERVAL"
       label: "IPSec CHILD_SA rekey time"
-      description: "Proceed with caution; typical users will not need to change this. Incorrect values can break your Rancher installation."
+      description: "This is an advanced setting and most users will not need to use this. Incorrect values can break your Rancher installation."
       type: "string"
       default: '1h'
       required: true
-
+    - variable: "RANCHER_IPSEC_PSK"
+      label: "PSK for IPSec"
+      description: "This is an advanced setting and most users will not need to use this. Incorrect values can break your Rancher installation."
+      type: "string"
+      default: ''
+      required: false
 ipsec:
   health_check:
     request_line: GET "/connectivity" "HTTP/1.0"

--- a/infra-templates/ipsec/config.yml
+++ b/infra-templates/ipsec/config.yml
@@ -1,5 +1,5 @@
 name: Rancher IPsec
-version: 0.2.2
+version: 0.2.3
 category: Networking
 labels:
   io.rancher.certified: rancher

--- a/infra-templates/k8s/40/README.md
+++ b/infra-templates/k8s/40/README.md
@@ -1,0 +1,51 @@
+## Kubernetes v1.8.5
+
+### Software Versions
+
+* Kubernetes v1.8.5
+* Etcd v2.3.7
+
+### Upgrading to this Version
+
+Warning: The existing template version _must be_ `v1.2.4-rancher9` or later. Ignoring this will result in data loss. For older templates, please first upgrade to `v1.5.4-rancher1`.
+
+### Changelog for Kubernetes v1.8.5
+
+* Added ability to check the versions of add-ons so they are not upgraded if they had been independently upgraded 
+* Added ability to keep config map for SkyDNS if it was set
+* Added ability to configure dashboard resource limits.
+* Added open-iscsi package.
+* Added support for Azure vnet in another resource group.
+
+### Required Open Ports on hosts
+
+ The following TCP ports are required to be open for `kubectl`: `10250` and `10255`. To access any exposed services, the ports used for the NodePort will also need to be opened. The default ports used by NodePort are TCP ports `30000` - `32767`.
+
+### Plane Isolation
+
+If you want to separate the planes for resiliency by labeling your hosts to separate out the data, orchestration and compute planes, you **must** change the plane isolation option to `required`. The host labels, `compute=true`, `orchestration=true` and `etcd=true`, are required on your hosts in order for Kubernetes to successfully launch. By default, `none` is selected and there will be no attempt for plane isolation.
+
+### KubeDNS
+
+KubeDNS is enabled for name resolution as described in the [Kubernetes DNS docs](http://kubernetes.io/docs/admin/dns/). The DNS service IP address is `10.43.0.10` by default.
+
+### Audit Logs
+
+Audit logs can be enabled through a simple option when deploying kubernetes, it will redirect all the Audit logs to the standard output for the kubernetes api container.
+
+### Using in a proxy environment
+
+By setting the HTTP_PROXY parameter, the `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` environment variables will be added to the kubernetes containers.
+
+### Azure Cloud provider support
+
+The native Kubernetes Azure cloud provider is now enabled in this template. Currently, Azure Load Balancers, Azure Files, Azure Blob and Managed disks are supported for appropriate VM types.
+
+It's possible to use Rancher-Machine-provisioned hosts or custom hosts created on Azure. Only hosts in the same resource group are currently supported. Also, for Azure Load Balancer to work, hosts that are expected to be in the Load balancer pool should be in the configured `Security Group`.
+
+The following parameters are required to use the Azure Cloud Provider:
+* **Azure Cloud Environment:** Select one of the available Azure Cloud Environments.
+* **Azure Tenant ID**: In your Azure Portal, go to `Azure Active Directory` and select `properties`. Your `Directory ID` is your `Tenant ID`. Also, you can run the command `az account show` in your Azure Shell to get the same information.
+* **Azure Client ID**: You can use the the procedure [here](http://rancher.com/docs/rancher/latest/en/hosts/azure/#app-registration) to create an App Registration.
+* **Azure Client Secret:** Created as part to the App Registration procedure.
+* **Azure Security Group:** Custom Azure Security Group needed to allow Azure Load Balancers to work. If you provision hosts using Rancher Machine Azure driver, you will need to edit them manually to assign them to this Security Group.

--- a/infra-templates/k8s/40/README.md
+++ b/infra-templates/k8s/40/README.md
@@ -1,21 +1,17 @@
-## Kubernetes v1.8.5
+## Kubernetes v1.9.0
 
 ### Software Versions
 
-* Kubernetes v1.8.5
+* Kubernetes v1.9.0
 * Etcd v2.3.7
 
 ### Upgrading to this Version
 
 Warning: The existing template version _must be_ `v1.2.4-rancher9` or later. Ignoring this will result in data loss. For older templates, please first upgrade to `v1.5.4-rancher1`.
 
-### Changelog for Kubernetes v1.8.5
+### Changelog for Kubernetes v1.9.0
 
-* Added ability to check the versions of add-ons so they are not upgraded if they had been independently upgraded 
-* Added ability to keep config map for SkyDNS if it was set
-* Added ability to configure dashboard resource limits.
-* Added open-iscsi package.
-* Added support for Azure vnet in another resource group.
+* 
 
 ### Required Open Ports on hosts
 

--- a/infra-templates/k8s/40/README.md
+++ b/infra-templates/k8s/40/README.md
@@ -1,17 +1,17 @@
-## Kubernetes v1.9.0
+## Kubernetes v1.9.1
 
 ### Software Versions
 
-* Kubernetes v1.9.0
+* Kubernetes v1.9.1
 * Etcd v2.3.7
 
 ### Upgrading to this Version
 
 Warning: The existing template version _must be_ `v1.2.4-rancher9` or later. Ignoring this will result in data loss. For older templates, please first upgrade to `v1.5.4-rancher1`.
 
-### Changelog for Kubernetes v1.9.0
+### Changelog for Kubernetes v1.9.1
 
-* 
+*
 
 ### Required Open Ports on hosts
 

--- a/infra-templates/k8s/40/docker-compose.yml.tpl
+++ b/infra-templates/k8s/40/docker-compose.yml.tpl
@@ -1,0 +1,439 @@
+
+{{- $k8sImage:="rancher/k8s:v1.8.5-rancher3" }}
+{{- $etcdImage:="rancher/etcd:v2.3.7-13" }}
+{{- $kubectldImage:="rancher/kubectld:v0.8.5" }}
+{{- $etcHostUpdaterImage:="rancher/etc-host-updater:v0.0.3" }}
+{{- $k8sAgentImage:="rancher/kubernetes-agent:v0.6.6" }}
+{{- $k8sAuthImage:="rancher/kubernetes-auth:v0.0.8" }}
+{{- $ingressControllerImage:="rancher/lb-service-rancher:v0.7.17" }}
+
+kubelet:
+    labels:
+        io.rancher.container.dns: "true"
+        io.rancher.container.dns.priority: "None"
+        io.rancher.container.create_agent: "true"
+        io.rancher.container.agent.role: environmentAdmin
+        io.rancher.scheduler.global: "true"
+        {{- if eq .Values.CONSTRAINT_TYPE "required" }}
+        io.rancher.scheduler.affinity:host_label: compute=true
+        {{- end }}
+    command:
+        - kubelet
+        - --kubeconfig=/etc/kubernetes/ssl/kubeconfig
+        - --allow-privileged=true
+        - --register-node=true
+        - --cloud-provider=${CLOUD_PROVIDER}
+        {{- if eq .Values.CLOUD_PROVIDER "azure" }}
+        - --cloud-config=/etc/kubernetes/cloud-provider-config
+        {{- end }}
+        - --healthz-bind-address=0.0.0.0
+        - --cluster-dns=${DNS_CLUSTER_IP}
+        - --fail-swap-on=${FAIL_ON_SWAP}
+        - --cluster-domain=cluster.local
+        - --network-plugin=cni
+        - --cni-conf-dir=/etc/cni/managed.d
+        {{- if and (ne .Values.REGISTRY "") (ne .Values.POD_INFRA_CONTAINER_IMAGE "") }}
+        - --pod-infra-container-image=${REGISTRY}/${POD_INFRA_CONTAINER_IMAGE}
+        {{- else if (ne .Values.POD_INFRA_CONTAINER_IMAGE "") }}
+        - --pod-infra-container-image=${POD_INFRA_CONTAINER_IMAGE}
+        {{- end }}
+        {{- range $i, $elem := splitPreserveQuotes .Values.ADDITIONAL_KUBELET_FLAGS }}
+        - {{ $elem }}
+        {{- end }}
+    environment:
+        CLOUD_PROVIDER: ${CLOUD_PROVIDER}
+    {{- if ne .Values.HTTP_PROXY "" }}
+        HTTP_PROXY: ${HTTP_PROXY}
+        HTTPS_PROXY: ${HTTP_PROXY}
+        NO_PROXY: ${NO_PROXY}
+    {{- end }}
+    {{- if eq .Values.CLOUD_PROVIDER "azure" }}
+        AZURE_TENANT_ID: ${AZURE_TENANT_ID}
+        AZURE_CLIENT_ID: ${AZURE_CLIENT_ID}
+        AZURE_CLIENT_SECRET: ${AZURE_CLIENT_SECRET}
+        AZURE_SEC_GROUP: ${AZURE_SEC_GROUP}
+        AZURE_CLOUD: ${AZURE_CLOUD}
+    {{- end }}
+    image: {{$k8sImage}}
+    volumes:
+        - /run:/run:rprivate
+        - /var/run:/var/run:rprivate
+        - /sys:/sys:ro,rprivate
+        - /var/lib/docker:/var/lib/docker:rprivate
+        - /var/lib/kubelet:/var/lib/kubelet:shared
+        - /var/log/containers:/var/log/containers:rprivate
+        - /var/log/pods:/var/log/pods:rprivate
+        - rancher-cni-driver:/etc/cni:ro
+        - rancher-cni-driver:/opt/cni:ro
+        - /dev:/host/dev:rprivate
+    net: host
+    pid: host
+    ipc: host
+    privileged: true
+    links:
+        - kubernetes
+
+{{- if eq .Values.CONSTRAINT_TYPE "required" }}
+kubelet-unschedulable:
+    labels:
+        io.rancher.container.dns: "true"
+        io.rancher.container.create_agent: "true"
+        io.rancher.container.agent.role: environmentAdmin
+        io.rancher.scheduler.global: "true"
+        io.rancher.scheduler.affinity:host_label_ne: compute=true
+    command:
+        - kubelet
+        - --kubeconfig=/etc/kubernetes/ssl/kubeconfig
+        - --allow-privileged=true
+        - --register-node=true
+        - --cloud-provider=${CLOUD_PROVIDER}
+        {{- if eq .Values.CLOUD_PROVIDER "azure" }}
+        - --cloud-config=/etc/kubernetes/cloud-provider-config
+        {{- end }}
+        - --healthz-bind-address=0.0.0.0
+        - --fail-swap-on=${FAIL_ON_SWAP}
+        - --cluster-dns=${DNS_CLUSTER_IP}
+        - --cluster-domain=cluster.local
+        - --network-plugin=cni
+        - --cni-conf-dir=/etc/cni/managed.d
+        {{- if and (ne .Values.REGISTRY "") (ne .Values.POD_INFRA_CONTAINER_IMAGE "") }}
+        - --pod-infra-container-image=${REGISTRY}/${POD_INFRA_CONTAINER_IMAGE}
+        {{- else if (ne .Values.POD_INFRA_CONTAINER_IMAGE "") }}
+        - --pod-infra-container-image=${POD_INFRA_CONTAINER_IMAGE}
+        {{- end }}
+        - --register-schedulable=false
+        {{- range $i, $elem := splitPreserveQuotes .Values.ADDITIONAL_KUBELET_FLAGS }}
+        - {{ $elem }}
+        {{- end }}
+    environment:
+        CLOUD_PROVIDER: ${CLOUD_PROVIDER}
+    {{- if ne .Values.HTTP_PROXY "" }}
+        HTTP_PROXY: ${HTTP_PROXY}
+        HTTPS_PROXY: ${HTTP_PROXY}
+        NO_PROXY: ${NO_PROXY}
+    {{- end }}
+    {{- if eq .Values.CLOUD_PROVIDER "azure" }}
+        AZURE_TENANT_ID: ${AZURE_TENANT_ID}
+        AZURE_CLIENT_ID: ${AZURE_CLIENT_ID}
+        AZURE_CLIENT_SECRET: ${AZURE_CLIENT_SECRET}
+        AZURE_SEC_GROUP: ${AZURE_SEC_GROUP}
+        AZURE_CLOUD: ${AZURE_CLOUD}
+    {{- end }}
+
+    image: {{$k8sImage}}
+    volumes:
+        - /run:/run:rprivate
+        - /var/run:/var/run:rprivate
+        - /sys:/sys:ro,rprivate
+        - /var/lib/docker:/var/lib/docker:rprivate
+        - /var/lib/kubelet:/var/lib/kubelet:shared
+        - /var/log/containers:/var/log/containers:rprivate
+        - /var/log/pods:/var/log/pods:rprivate
+        - rancher-cni-driver:/etc/cni:ro
+        - rancher-cni-driver:/opt/cni:ro
+        - /dev:/host/dev:rprivate
+    net: host
+    pid: host
+    ipc: host
+    privileged: true
+    links:
+        - kubernetes
+{{- end }}
+
+proxy:
+    command:
+        - kube-proxy
+        - --kubeconfig=/etc/kubernetes/ssl/kubeconfig
+        - --v=2
+        - --healthz-bind-address=0.0.0.0
+    image: {{$k8sImage}}
+    labels:
+        io.rancher.container.dns: "true"
+        io.rancher.scheduler.global: "true"
+        io.rancher.container.create_agent: "true"
+        io.rancher.container.agent.role: environmentAdmin
+    privileged: true
+    net: host
+    links:
+        - kubernetes
+
+etcd:
+    image: {{$etcdImage}}
+    labels:
+        {{- if eq .Values.CONSTRAINT_TYPE "required" }}
+        io.rancher.scheduler.affinity:host_label: etcd=true
+        {{- end }}
+        io.rancher.scheduler.affinity:container_label_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
+        io.rancher.sidekicks: data
+    environment:
+        RANCHER_DEBUG: 'true'
+        EMBEDDED_BACKUPS: '${EMBEDDED_BACKUPS}'
+        BACKUP_PERIOD: '${BACKUP_PERIOD}'
+        BACKUP_RETENTION: '${BACKUP_RETENTION}'
+        ETCD_HEARTBEAT_INTERVAL: '${ETCD_HEARTBEAT_INTERVAL}'
+        ETCD_ELECTION_TIMEOUT: '${ETCD_ELECTION_TIMEOUT}'
+    volumes:
+    - etcd:/pdata:z
+    - /var/etcd/backups:/data-backup:z
+
+data:
+    image: busybox
+    entrypoint: /bin/true
+    net: none
+    volumes:
+    - /data
+    labels:
+        io.rancher.container.start_once: 'true'
+
+kubernetes:
+    labels:
+        {{- if eq .Values.CONSTRAINT_TYPE "required" }}
+        io.rancher.scheduler.affinity:host_label: orchestration=true
+        {{- end }}
+        io.rancher.scheduler.affinity:container_label_soft: io.rancher.stack_service.name=$${stack_name}/rancher-kubernetes-auth
+        io.rancher.container.create_agent: "true"
+        io.rancher.container.agent.role: environmentAdmin
+        io.rancher.sidekicks: kube-hostname-updater
+        io.rancher.websocket.proxy.port: "6443"
+        io.rancher.websocket.proxy.scheme: "https"
+    command:
+        - kube-apiserver
+        - --storage-backend=etcd2
+        - --service-cluster-ip-range=${SERVICE_CLUSTER_CIDR}
+        - --etcd-servers=http://etcd.kubernetes.rancher.internal:2379
+        - --insecure-bind-address=0.0.0.0
+        - --insecure-port=0
+        - --cloud-provider=${CLOUD_PROVIDER}
+        {{- if eq .Values.CLOUD_PROVIDER "azure" }}
+        - --cloud-config=/etc/kubernetes/cloud-provider-config
+        {{- end }}
+        - --allow_privileged=true
+        - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,DefaultStorageClass,ResourceQuota,DefaultTolerationSeconds
+        - --client-ca-file=/etc/kubernetes/ssl/ca.pem
+        - --tls-cert-file=/etc/kubernetes/ssl/cert.pem
+        - --tls-private-key-file=/etc/kubernetes/ssl/key.pem
+        - --runtime-config=batch/v2alpha1
+        - --authentication-token-webhook-config-file=/etc/kubernetes/authconfig
+        - --runtime-config=authentication.k8s.io/v1beta1=true
+        - --external-hostname=kubernetes.kubernetes.rancher.internal
+        {{- if eq .Values.AUDIT_LOGS "true" }}
+        - --audit-log-path=-
+        {{- end }}
+        {{- if eq .Values.RBAC "true" }}
+        - --authorization-mode=RBAC
+        {{- end }}
+    environment:
+        KUBERNETES_URL: https://kubernetes.kubernetes.rancher.internal:6443
+        {{- if ne .Values.HTTP_PROXY "" }}
+        HTTP_PROXY: ${HTTP_PROXY}
+        HTTPS_PROXY: ${HTTP_PROXY}
+        NO_PROXY: ${NO_PROXY}
+        {{- end }}
+        {{- if eq .Values.CLOUD_PROVIDER "azure" }}
+        AZURE_TENANT_ID: ${AZURE_TENANT_ID}
+        AZURE_CLIENT_ID: ${AZURE_CLIENT_ID}
+        AZURE_CLIENT_SECRET: ${AZURE_CLIENT_SECRET}
+        AZURE_SEC_GROUP: ${AZURE_SEC_GROUP}
+        AZURE_CLOUD: ${AZURE_CLOUD}
+        {{- end }}
+
+    image: {{$k8sImage}}
+    links:
+        - etcd
+
+kube-hostname-updater:
+    net: container:kubernetes
+    command:
+        - etc-host-updater
+    image: {{$etcHostUpdaterImage}}
+    links:
+        - kubernetes
+
+kubectld:
+    labels:
+        {{- if eq .Values.CONSTRAINT_TYPE "required" }}
+        io.rancher.scheduler.affinity:host_label: orchestration=true
+        {{- end }}
+        io.rancher.container.create_agent: "true"
+        io.rancher.container.agent_service.kubernetes_stack: "true"
+    environment:
+        SERVER: http://kubernetes.kubernetes.rancher.internal
+        LISTEN: ":8091"
+    image: {{$kubectldImage}}
+    links:
+        - kubernetes
+
+kubectl-shell:
+    labels:
+        {{- if eq .Values.CONSTRAINT_TYPE "required" }}
+        io.rancher.scheduler.affinity:host_label: orchestration=true
+        {{- end }}
+        io.rancher.container.create_agent: "true"
+        io.rancher.container.agent.role: environmentAdmin
+        io.rancher.k8s.kubectld: "true"
+        io.rancher.k8s.token: "true"
+    command:
+        - kubectl-shell-entry.sh
+    image: {{$kubectldImage}}
+    privileged: true
+    health_check:
+        port: 10240
+        interval: 2000
+        response_timeout: 2000
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+        initializing_timeout: 60000
+        reinitializing_timeout: 60000
+
+
+scheduler:
+    command:
+        - kube-scheduler
+        - --kubeconfig=/etc/kubernetes/ssl/kubeconfig
+        - --address=0.0.0.0
+    image: {{$k8sImage}}
+    labels:
+        {{- if eq .Values.CONSTRAINT_TYPE "required" }}
+        io.rancher.scheduler.affinity:host_label: orchestration=true
+        {{- end }}
+        io.rancher.container.create_agent: "true"
+        io.rancher.container.agent.role: environmentAdmin
+    links:
+        - kubernetes
+
+controller-manager:
+    command:
+        - kube-controller-manager
+        - --kubeconfig=/etc/kubernetes/ssl/kubeconfig
+        - --allow-untagged-cloud
+        - --cloud-provider=${CLOUD_PROVIDER}
+        {{- if eq .Values.CLOUD_PROVIDER "azure" }}
+        - --cloud-config=/etc/kubernetes/cloud-provider-config
+        {{- end }}
+        - --address=0.0.0.0
+        - --root-ca-file=/etc/kubernetes/ssl/ca.pem
+        - --service-account-private-key-file=/etc/kubernetes/ssl/key.pem
+    environment:
+        CLOUD_PROVIDER: ${CLOUD_PROVIDER}
+        {{- if ne .Values.HTTP_PROXY "" }}
+        HTTP_PROXY: ${HTTP_PROXY}
+        HTTPS_PROXY: ${HTTP_PROXY}
+        NO_PROXY: ${NO_PROXY}
+        {{- end }}
+        {{- if eq .Values.CLOUD_PROVIDER "azure" }}
+        AZURE_TENANT_ID: ${AZURE_TENANT_ID}
+        AZURE_CLIENT_ID: ${AZURE_CLIENT_ID}
+        AZURE_CLIENT_SECRET: ${AZURE_CLIENT_SECRET}
+        AZURE_SEC_GROUP: ${AZURE_SEC_GROUP}
+        AZURE_CLOUD: ${AZURE_CLOUD}
+        {{- end }}
+    image: {{$k8sImage}}
+    labels:
+        {{- if eq .Values.CONSTRAINT_TYPE "required" }}
+        io.rancher.scheduler.affinity:host_label: orchestration=true
+        {{- end }}
+        io.rancher.container.create_agent: "true"
+        io.rancher.container.agent.role: environmentAdmin
+    links:
+        - kubernetes
+
+rancher-kubernetes-agent:
+    labels:
+        {{- if eq .Values.CONSTRAINT_TYPE "required" }}
+        io.rancher.scheduler.affinity:host_label: orchestration=true
+        {{- end }}
+        io.rancher.container.create_agent: "true"
+        io.rancher.container.agent.role: agent,environmentAdmin
+        io.rancher.container.agent_service.labels_provider: "true"
+        io.rancher.k8s.agent: "true"
+    environment:
+        KUBERNETES_URL: https://kubernetes.kubernetes.rancher.internal:6443
+    image: {{$k8sAgentImage}}
+    privileged: true
+    volumes:
+        - /var/run/docker.sock:/var/run/docker.sock
+    links:
+        - kubernetes
+
+{{- if eq .Values.ENABLE_RANCHER_INGRESS_CONTROLLER "true" }}
+rancher-ingress-controller:
+    image: {{$ingressControllerImage}}
+    labels:
+        {{- if eq .Values.CONSTRAINT_TYPE "required" }}
+        io.rancher.scheduler.affinity:host_label: orchestration=true
+        {{- end }}
+        io.rancher.container.create_agent: "true"
+        io.rancher.container.agent.role: environmentAdmin
+    environment:
+        KUBERNETES_URL: https://kubernetes.kubernetes.rancher.internal:6443
+        RANCHER_LB_SEPARATOR: $RANCHER_LB_SEPARATOR
+    command:
+        - lb-controller
+        - --controller=kubernetes
+        - --provider=rancher
+    links:
+        - kubernetes
+    health_check:
+        request_line: GET /healthz HTTP/1.0
+        port: 10241
+        interval: 2000
+        response_timeout: 2000
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+        initializing_timeout: 60000
+        reinitializing_timeout: 60000
+{{- end }}
+
+rancher-kubernetes-auth:
+    image: {{$k8sAuthImage}}
+    labels:
+        {{- if eq .Values.CONSTRAINT_TYPE "required" }}
+        io.rancher.scheduler.affinity:host_label: orchestration=true
+        {{- end }}
+        io.rancher.scheduler.affinity:container_label: io.rancher.stack_service.name=$${stack_name}/kubernetes
+        io.rancher.container.create_agent: "true"
+        io.rancher.container.agent.role: environmentAdmin
+    health_check:
+        request_line: GET /healthcheck HTTP/1.0
+        port: 10240
+        interval: 2000
+        response_timeout: 2000
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+        initializing_timeout: 60000
+        reinitializing_timeout: 60000
+
+{{- if eq .Values.ENABLE_ADDONS "true" }}
+addon-starter:
+    image: {{$k8sImage}}
+    labels:
+        {{- if eq .Values.CONSTRAINT_TYPE "required" }}
+        io.rancher.scheduler.affinity:host_label: orchestration=true
+        {{- end }}
+        io.rancher.container.create_agent: 'true'
+        io.rancher.container.agent.role: environmentAdmin
+    environment:
+        KUBERNETES_URL: https://kubernetes.kubernetes.rancher.internal:6443
+        REGISTRY: ${REGISTRY}
+        INFLUXDB_HOST_PATH: ${INFLUXDB_HOST_PATH}
+        DNS_REPLICAS: ${DNS_REPLICAS}
+        DNS_CLUSTER_IP: ${DNS_CLUSTER_IP}
+        BASE_IMAGE_NAMESPACE: ${BASE_IMAGE_NAMESPACE}
+        HELM_IMAGE_NAMESPACE: ${HELM_IMAGE_NAMESPACE}
+        ADDONS_LOG_VERBOSITY_LEVEL: ${ADDONS_LOG_VERBOSITY_LEVEL}
+        DASHBOARD_CPU_LIMIT: ${DASHBOARD_CPU_LIMIT}
+        DASHBOARD_MEMORY_LIMIT: ${DASHBOARD_MEMORY_LIMIT}
+
+    command:
+        - addons-update.sh
+    links:
+        - kubernetes
+    health_check:
+        port: 10240
+        interval: 2000
+        response_timeout: 2000
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+        initializing_timeout: 60000
+        reinitializing_timeout: 60000
+{{- end }}

--- a/infra-templates/k8s/40/docker-compose.yml.tpl
+++ b/infra-templates/k8s/40/docker-compose.yml.tpl
@@ -1,5 +1,5 @@
 
-{{- $k8sImage:="rancher/k8s:v1.9.0-rancher2-2" }}
+{{- $k8sImage:="rancher/k8s:v1.9.1-rancher1-1" }}
 {{- $etcdImage:="rancher/etcd:v2.3.7-13" }}
 {{- $kubectldImage:="rancher/kubectld:v0.8.6" }}
 {{- $etcHostUpdaterImage:="rancher/etc-host-updater:v0.0.3" }}

--- a/infra-templates/k8s/40/docker-compose.yml.tpl
+++ b/infra-templates/k8s/40/docker-compose.yml.tpl
@@ -1,7 +1,7 @@
 
 {{- $k8sImage:="rancher/k8s:v1.9.0-rancher2-1" }}
 {{- $etcdImage:="rancher/etcd:v2.3.7-13" }}
-{{- $kubectldImage:="rancher/kubectld:v0.8.5" }}
+{{- $kubectldImage:="rancher/kubectld:v0.8.6" }}
 {{- $etcHostUpdaterImage:="rancher/etc-host-updater:v0.0.3" }}
 {{- $k8sAgentImage:="rancher/kubernetes-agent:v0.6.6" }}
 {{- $k8sAuthImage:="rancher/kubernetes-auth:v0.0.8" }}

--- a/infra-templates/k8s/40/docker-compose.yml.tpl
+++ b/infra-templates/k8s/40/docker-compose.yml.tpl
@@ -1,5 +1,5 @@
 
-{{- $k8sImage:="rancher/k8s:v1.9.0-rancher2-1" }}
+{{- $k8sImage:="rancher/k8s:v1.9.0-rancher2-2" }}
 {{- $etcdImage:="rancher/etcd:v2.3.7-13" }}
 {{- $kubectldImage:="rancher/kubectld:v0.8.6" }}
 {{- $etcHostUpdaterImage:="rancher/etc-host-updater:v0.0.3" }}

--- a/infra-templates/k8s/40/docker-compose.yml.tpl
+++ b/infra-templates/k8s/40/docker-compose.yml.tpl
@@ -199,6 +199,7 @@ kubernetes:
     command:
         - kube-apiserver
         - --storage-backend=etcd2
+        - --storage-media-type=application/json
         - --service-cluster-ip-range=${SERVICE_CLUSTER_CIDR}
         - --etcd-servers=http://etcd.kubernetes.rancher.internal:2379
         - --insecure-bind-address=0.0.0.0

--- a/infra-templates/k8s/40/docker-compose.yml.tpl
+++ b/infra-templates/k8s/40/docker-compose.yml.tpl
@@ -213,6 +213,7 @@ kubernetes:
         - --tls-cert-file=/etc/kubernetes/ssl/cert.pem
         - --tls-private-key-file=/etc/kubernetes/ssl/key.pem
         - --runtime-config=batch/v2alpha1
+        - --anonymous-auth=false
         - --authentication-token-webhook-config-file=/etc/kubernetes/authconfig
         - --runtime-config=authentication.k8s.io/v1beta1=true
         - --external-hostname=kubernetes.kubernetes.rancher.internal

--- a/infra-templates/k8s/40/docker-compose.yml.tpl
+++ b/infra-templates/k8s/40/docker-compose.yml.tpl
@@ -1,5 +1,5 @@
 
-{{- $k8sImage:="rancher/k8s:v1.8.5-rancher3" }}
+{{- $k8sImage:="rancher/k8s:v1.9.0-rancher2-1" }}
 {{- $etcdImage:="rancher/etcd:v2.3.7-13" }}
 {{- $kubectldImage:="rancher/kubectld:v0.8.5" }}
 {{- $etcHostUpdaterImage:="rancher/etc-host-updater:v0.0.3" }}

--- a/infra-templates/k8s/40/docker-compose.yml.tpl
+++ b/infra-templates/k8s/40/docker-compose.yml.tpl
@@ -209,7 +209,7 @@ kubernetes:
         - --cloud-config=/etc/kubernetes/cloud-provider-config
         {{- end }}
         - --allow_privileged=true
-        - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,DefaultStorageClass,ResourceQuota,DefaultTolerationSeconds
+        - --admission-control=$ADMISSION_CONTROLLERS
         - --client-ca-file=/etc/kubernetes/ssl/ca.pem
         - --tls-cert-file=/etc/kubernetes/ssl/cert.pem
         - --tls-private-key-file=/etc/kubernetes/ssl/key.pem

--- a/infra-templates/k8s/40/docker-compose.yml.tpl
+++ b/infra-templates/k8s/40/docker-compose.yml.tpl
@@ -220,6 +220,7 @@ kubernetes:
         - --external-hostname=kubernetes.kubernetes.rancher.internal
         {{- if eq .Values.AUDIT_LOGS "true" }}
         - --audit-log-path=-
+        - --feature-gates=AdvancedAuditing=false
         {{- end }}
         {{- if eq .Values.RBAC "true" }}
         - --authorization-mode=RBAC

--- a/infra-templates/k8s/40/rancher-compose.yml
+++ b/infra-templates/k8s/40/rancher-compose.yml
@@ -1,0 +1,304 @@
+.catalog:
+  name: Kubernetes
+  version: v1.8.5-rancher3
+  description: Rancher Kubernetes service
+  minimum_rancher_version: v1.6.13-rc1
+  questions:
+  - variable: CONSTRAINT_TYPE
+    label: Plane Isolation
+    description: Isolate the data, orchestration and compute planes via host labels. Set to required when running in production.
+    required: true
+    default: none
+    type: enum
+    options:
+    - none
+    - required
+  - variable: CLOUD_PROVIDER
+    label: Cloud Provider
+    description: The cloud provider on which Kubernetes is running
+    required: true
+    default: rancher
+    type: enum
+    options:
+     - rancher
+     - aws
+     - azure
+  - variable: AZURE_CLOUD
+    label: Azure Cloud Environment
+    description: The Azure Cloud environment identifier.
+    required: false
+    default: AzurePublicCloud
+    type: enum
+    options:
+      - AzurePublicCloud
+      - AzureUSGovernmentCloud
+      - AzureChinaCloud
+      - AzureGermanCloud
+  - variable: AZURE_TENANT_ID
+    label: Azure Tenant ID
+    description: The Azure Active Directory Tenant ID for the Azure Subscription where the cluster will be deployed.
+    required: false
+    default: ""
+    type: string
+  - variable: AZURE_CLIENT_ID
+    label: Azure Client ID
+    description: The Client ID for an Azure Active Directory application with access to talk to Azure APIs.
+    required: false
+    default: ""
+    type: string
+  - variable: AZURE_CLIENT_SECRET
+    label: Azure Client Secret
+    description: The Client Secret for an Azure Active Directory application with access to talk to Azure APIs.
+    required: false
+    default: ""
+    type: string
+  - variable: AZURE_SEC_GROUP
+    label: Azure Security Group
+    description: The Azure Security Group for the hosts in the cluster. This is required for Azure Load Balancer to work. In case you provisioned your hosts using the Rancher Machine drvier for Azure, you will need to use the Azure Portal to edit the hosts' Security Group to the one selected here. Only hosts expected to be Load Balancer Backends need to be in this group.
+    required: false
+    type: string
+    default: ""
+  - variable: RBAC
+    description: Enable Kubernetes role-based access control with integrated Rancher authentication.
+    label: Kubernetes RBAC
+    required: true
+    default: false
+    type: boolean
+  - variable: REGISTRY
+    description: "The registry to pull addon images and the optional pod infra container image. This should be set to the private registry from which the images for addon-services (i.e. helm, heapster, dashboard, dns) and the pod infra container image should be pulled. ( Default: gcr.io )."
+    label: Private Registry for Add-Ons and Pod Infra Container Image
+    required: false
+    default: ""
+    type: string
+  - variable: BASE_IMAGE_NAMESPACE
+    description: "Image namespace for Add-Ons and Pod Infra Container Image ( Default: google_containers )."
+    label: Image namespace for  Add-Ons and Pod Infra Container Image
+    required: false
+    default: ""
+    type: string
+  - variable: HELM_IMAGE_NAMESPACE
+    description: "Image namespace for kubernetes-helm ( Default: kubernetes-helm )."
+    label: Image namespace for kubernetes-helm Image
+    required: false
+    default: ""
+    type: string
+  - variable: DNS_REPLICAS
+    description: Number of replicas for SKY DNS service. Each replica would run on the separate host, so change the value according to your infrastructure.
+    label: Sky DNS service scale
+    required: false
+    default: 1
+    type: int
+  - variable: ENABLE_RANCHER_INGRESS_CONTROLLER
+    description: Deploy the Rancher ingress controller which automatically provisions Rancher load balancers in response to Kubernetes ingress creation events.
+    label: Enable Rancher Ingress Controller
+    required: true
+    default: true
+    type: boolean
+  - variable: FAIL_ON_SWAP
+    label: Fail on swap
+    description: Kubelet will fail if swap is enabled on the host.
+    default: false
+    type: enum
+    options:
+      - true
+      - false
+    required: true
+  - variable: ENABLE_ADDONS
+    label: Enable Kubernetes Add-ons
+    description: Setting this to `false` will disable Dashboard, Helm, SkyDNS, and other Kubernetes add-on services. This is meant for advanced users who want to deploy custom versions of these add-ons.
+    required: true
+    default: true
+    type: boolean
+  - variable: ADDONS_LOG_VERBOSITY_LEVEL
+    label: Log versions level for Kubernetes Add-ons
+    description: Log verbosity level for the Kubernetes Add-ons. Numbers 0-4 are debug-level logs, and 5-10 are trace-level logs.
+    default: 2
+    type: enum
+    options:
+      - 0
+      - 1
+      - 2
+      - 3
+      - 4
+      - 5
+      - 6
+      - 7
+      - 8
+      - 9
+      - 10
+    required: false
+  - variable: POD_INFRA_CONTAINER_IMAGE
+    label: Pod Infra Container Image
+    description: The image whose network/ipc namespaces containers in each pod will use. It uses kubelet default if left empty. Do not add the private registry to this field, update the `Private Registry for Add-Ons and Pod Infra Container Image` field with the registry information.
+    required: false
+    default: "gcr.io/google_containers/pause-amd64:3.0"
+    type: string
+  - variable: AUDIT_LOGS
+    description: Enable Audit logs to stdout for the kube-apiserver
+    label: Audit Logs
+    required: false
+    default: false
+    type: boolean
+  - variable: SERVICE_CLUSTER_CIDR
+    label: Service Cluster IP CIDR
+    description: A CIDR notation IP range from which to assign service cluster IPs. This must not overlap with any IP ranges assigned to the cluster pod IP CIDR (10.42.0.0/16).
+    required: true
+    default: "10.43.0.0/16"
+    type: string
+  - variable: DNS_CLUSTER_IP
+    label: KubeDNS cluster IP
+    description: The IP address assigned to kubedns service. This must be within the range of Service Cluster IP CIDR.
+    required: true
+    default: "10.43.0.10"
+    type: string
+  - variable: KUBEAPI_CLUSTER_IP
+    label: KubeAPI cluster IP for TLS certificate
+    description: This is the IP address that will be added as a SAN to the TLS certificate for kubernetes api, this must matches the IP of the kubernetes master service which is the first IP of the Service Cluster IP CIDR.
+    required: true
+    default: "10.43.0.1"
+    type: string
+  - variable: DASHBOARD_CPU_LIMIT
+    label: Kubernetes Dashboard CPU limit
+    description: This is the CPU allocated for the Dashboard pod. The same value is used for resource request and resource limit.
+    required: false
+    default: 100m
+    type: string
+  - variable: DASHBOARD_MEMORY_LIMIT
+    label: Kubernetes Dashboard memory limit
+    description: This is the memory allocated for the Dashboard pod. The same value is used for resource request and resource limit. If you have a large number of pods, you should increase this over the default value.
+    required: false
+    default: 300Mi
+    type: string
+  - variable: INFLUXDB_HOST_PATH
+    label: InfluxDB Host Path
+    description: "Write Heapster metrics to an absolute path on the host. This may be network-attached storage."
+    required: false
+    type: string
+  - variable: ADDITIONAL_KUBELET_FLAGS
+    label: Additional Kubelet Flags
+    required: false
+    type: string
+  - variable: EMBEDDED_BACKUPS
+    label: Enable Backups
+    description: "Periodically backup state to /var/etcd/backups. Mount network storage here on all hosts before continuing"
+    required: true
+    default: true
+    type: boolean
+  - variable: BACKUP_PERIOD
+    label: Backup Creation Period
+    description: Create a backup after this amount of time passes. Must conform to duration format
+    required: true
+    default: 15m0s
+    type: string
+  - variable: BACKUP_RETENTION
+    label: Backup Retention Period
+    description: Expire a backup after this amount of time passes. Must conform to duration format
+    required: true
+    default: 24h
+    type: string
+  - variable: ETCD_HEARTBEAT_INTERVAL
+    label: Etcd Heartbeat Interval
+    description: Time (in milliseconds) of a heartbeat interval.
+    required: true
+    default: 500
+    type: int
+  - variable: ETCD_ELECTION_TIMEOUT
+    label: Etcd Election Timeout
+    description: Time (in milliseconds) for an election to timeout.
+    required: true
+    default: 5000
+    type: int
+  - variable: RANCHER_LB_SEPARATOR
+    description: Separator used in Rancher LB names generated by ingress controller
+    label: Rancher LB name separator
+    required: false
+    default: rancherlb
+    type: string
+  - variable: HTTP_PROXY
+    description: "To be used when Kubernetes services are deployed on host(s) behind a proxy, i.e.: http(s)://<fqdn>:<port>"
+    label: HTTP proxy to be used by Kubernetes services
+    required: false
+    type: string
+  - variable: NO_PROXY
+    description: Comma separated string used to be excluded from the proxy
+    label: no_proxy to be used by Kubernetes services
+    required: false
+    default: rancher.internal,cluster.local,rancher-metadata,rancher-kubernetes-auth,kubernetes,169.254.169.254,169.254.169.250,10.42.0.0/16,10.43.0.0/16
+    type: string
+
+kubernetes:
+    metadata:
+        sans:
+        - "IP:${KUBEAPI_CLUSTER_IP}"
+        - "kubernetes.default.svc.cluster.local"
+    health_check:
+        port: 6443
+        interval: 2000
+        response_timeout: 2000
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+        initializing_timeout: 60000
+        reinitializing_timeout: 60000
+    retain_ip: true
+
+etcd:
+    retain_ip: true
+    scale_policy:
+        increment: 1
+        max: 3
+        min: 1
+    health_check:
+        port: 2378
+        request_line: GET /health HTTP/1.0
+        interval: 5000
+        response_timeout: 3000
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+        initializing_timeout: 600000
+        reinitializing_timeout: 120000
+        recreate_on_quorum_strategy_config:
+            quorum: 2
+        strategy: recreateOnQuorum
+
+rancher-kubernetes-agent:
+    health_check:
+        request_line: GET /healthcheck HTTP/1.0
+        port: 10240
+        interval: 2000
+        response_timeout: 2000
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+        initializing_timeout: 60000
+        reinitializing_timeout: 60000
+
+scheduler:
+    health_check:
+        request_line: GET /healthz HTTP/1.0
+        port: 10251
+        interval: 2000
+        response_timeout: 2000
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+        initializing_timeout: 60000
+        reinitializing_timeout: 60000
+
+controller-manager:
+    health_check:
+        request_line: GET /healthz HTTP/1.0
+        port: 10252
+        interval: 2000
+        response_timeout: 2000
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+        initializing_timeout: 60000
+        reinitializing_timeout: 60000
+
+kubectld:
+    health_check:
+        port: 10240
+        interval: 2000
+        response_timeout: 2000
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+        initializing_timeout: 60000
+        reinitializing_timeout: 60000

--- a/infra-templates/k8s/40/rancher-compose.yml
+++ b/infra-templates/k8s/40/rancher-compose.yml
@@ -1,6 +1,6 @@
 .catalog:
   name: Kubernetes
-  version: v1.9.0-rancher2-2
+  version: v1.9.1-rancher1-1
   description: Rancher Kubernetes service
   minimum_rancher_version: v1.6.13-rc1
   questions:

--- a/infra-templates/k8s/40/rancher-compose.yml
+++ b/infra-templates/k8s/40/rancher-compose.yml
@@ -1,6 +1,6 @@
 .catalog:
   name: Kubernetes
-  version: v1.9.0-rancher2-1
+  version: v1.9.0-rancher2-2
   description: Rancher Kubernetes service
   minimum_rancher_version: v1.6.13-rc1
   questions:

--- a/infra-templates/k8s/40/rancher-compose.yml
+++ b/infra-templates/k8s/40/rancher-compose.yml
@@ -1,6 +1,6 @@
 .catalog:
   name: Kubernetes
-  version: v1.8.5-rancher3
+  version: v1.9.0-rancher2-1
   description: Rancher Kubernetes service
   minimum_rancher_version: v1.6.13-rc1
   questions:

--- a/infra-templates/k8s/40/rancher-compose.yml
+++ b/infra-templates/k8s/40/rancher-compose.yml
@@ -139,6 +139,12 @@
     required: false
     default: false
     type: boolean
+  - variable: ADMISSION_CONTROLLERS
+    description: Admission controllers intercept requests to the Kubernetes API server after they are authenticated and authorized. Admission controllers validate and/or mutate objects in the requests before they are persisted, and they are processed in order.
+    label: Kubernetes Admission controllers
+    required: false
+    default:  NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,DefaultStorageClass,DefaultTolerationSeconds,ResourceQuota
+    type: string
   - variable: SERVICE_CLUSTER_CIDR
     label: Service Cluster IP CIDR
     description: A CIDR notation IP range from which to assign service cluster IPs. This must not overlap with any IP ranges assigned to the cluster pod IP CIDR (10.42.0.0/16).

--- a/infra-templates/k8s/config.yml
+++ b/infra-templates/k8s/config.yml
@@ -1,5 +1,5 @@
 name: Kubernetes
-version: v1.9.0-rancher2-2
+version: v1.9.1-rancher1-1
 category: Orchestration
 labels:
   io.rancher.certified: rancher

--- a/infra-templates/k8s/config.yml
+++ b/infra-templates/k8s/config.yml
@@ -1,5 +1,5 @@
 name: Kubernetes
-version: v1.9.0-rancehr2-1
+version: v1.9.0-rancher2-2
 category: Orchestration
 labels:
   io.rancher.certified: rancher

--- a/infra-templates/k8s/config.yml
+++ b/infra-templates/k8s/config.yml
@@ -1,5 +1,5 @@
 name: Kubernetes
-version: v1.8.5-rancher4
+version: v1.9.0-rancehr2-1
 category: Orchestration
 labels:
   io.rancher.certified: rancher

--- a/infra-templates/network-policy-manager/1/rancher-compose.yml
+++ b/infra-templates/network-policy-manager/1/rancher-compose.yml
@@ -2,3 +2,4 @@
   name: Network Policy Manager
   version: v0.0.2
   minimum_rancher_version: v1.5.0-rc1
+  maximum_rancher_version: v1.6.14

--- a/infra-templates/network-policy-manager/2/README.md
+++ b/infra-templates/network-policy-manager/2/README.md
@@ -1,0 +1,8 @@
+## Network Policy Manager
+
+Manager that applies Rancher network policies.
+
+### Changelog - 0.0.3
+
+#### Policy Manager [rancher/network-policy-manager:v0.2.5]
+* Added support for regions

--- a/infra-templates/network-policy-manager/2/README.md
+++ b/infra-templates/network-policy-manager/2/README.md
@@ -4,5 +4,5 @@ Manager that applies Rancher network policies.
 
 ### Changelog - 0.0.3
 
-#### Policy Manager [rancher/network-policy-manager:v0.2.5]
+#### Policy Manager [rancher/network-policy-manager:v0.2.6]
 * Added support for regions

--- a/infra-templates/network-policy-manager/2/docker-compose.yml
+++ b/infra-templates/network-policy-manager/2/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '2'
+services:
+  network-policy-manager:
+    privileged: true
+    network_mode: host
+    pid: host
+    image: rancher/network-policy-manager:v0.2.4
+    labels:
+      io.rancher.scheduler.global: 'true'
+    logging:
+      driver: json-file
+      options:
+        max-size: 25m
+        max-file: '2'

--- a/infra-templates/network-policy-manager/2/docker-compose.yml.tpl
+++ b/infra-templates/network-policy-manager/2/docker-compose.yml.tpl
@@ -1,10 +1,13 @@
 version: '2'
+
+{{- $npmImage:="rancher/network-policy-manager:v0.2.5" }}
+
 services:
   network-policy-manager:
     privileged: true
     network_mode: host
     pid: host
-    image: rancher/network-policy-manager:v0.2.4
+    image: {{$npmImage}}
     labels:
       io.rancher.scheduler.global: 'true'
     logging:

--- a/infra-templates/network-policy-manager/2/docker-compose.yml.tpl
+++ b/infra-templates/network-policy-manager/2/docker-compose.yml.tpl
@@ -1,6 +1,6 @@
 version: '2'
 
-{{- $npmImage:="rancher/network-policy-manager:v0.2.5" }}
+{{- $npmImage:="rancher/network-policy-manager:v0.2.6" }}
 
 services:
   network-policy-manager:

--- a/infra-templates/network-policy-manager/2/rancher-compose.yml
+++ b/infra-templates/network-policy-manager/2/rancher-compose.yml
@@ -1,0 +1,4 @@
+.catalog:
+  name: Network Policy Manager
+  version: v0.0.2
+  minimum_rancher_version: v1.5.0-rc1

--- a/infra-templates/network-policy-manager/2/rancher-compose.yml
+++ b/infra-templates/network-policy-manager/2/rancher-compose.yml
@@ -1,4 +1,4 @@
 .catalog:
   name: Network Policy Manager
-  version: v0.0.2
-  minimum_rancher_version: v1.5.0-rc1
+  version: v0.0.3
+  minimum_rancher_version: v1.6.15-rc1

--- a/infra-templates/network-policy-manager/config.yml
+++ b/infra-templates/network-policy-manager/config.yml
@@ -1,7 +1,7 @@
 name: Network Policy Manager
 description: |
   Manager that applies Rancher network policies.
-version: v0.0.2
+version: v0.0.3
 category: Networking
 labels:
   io.rancher.certified: rancher

--- a/infra-templates/network-services/26/rancher-compose.yml
+++ b/infra-templates/network-services/26/rancher-compose.yml
@@ -2,6 +2,7 @@
     name: Network Services
     version: v0.2.8
     minimum_rancher_version: v1.6.13-rc1
+    maximum_rancher_version: v1.6.14
     questions:
     - variable: DNS_RECURSER_TIMEOUT
       label: Timeout for Rancher DNS Recurser

--- a/infra-templates/network-services/27/README.md
+++ b/infra-templates/network-services/27/README.md
@@ -1,0 +1,27 @@
+## Network Services
+
+This stack provides the following services:
+
+* Metadata
+* DNS
+* Network Manager
+
+### Changelog for v0.2.8
+
+#### Network Manager [rancher/network-manager:v0.7.19]
+* Fixed issue with a new host added takes time to be active
+
+#### Metadata [rancher/metadata:v0.9.5]
+
+### Configuration Options
+
+#### dns
+
+* `DNS_RECURSER_TIMEOUT`
+* `TTL`
+
+#### metadata
+
+* `CPU_PERIOD`
+* `CPU_QUOTA`
+* `RELOAD_INTERVAL_LIMIT`

--- a/infra-templates/network-services/27/README.md
+++ b/infra-templates/network-services/27/README.md
@@ -14,6 +14,10 @@ This stack provides the following services:
 #### DNS [rancher/dns:v0.17.1]
 * Added regions support
 
+#### Network Manager [rancher/network-manager:v0.7.20]
+* Fixes issue during startup of healthcheck not able to reach server.
+* Fixes issue with deletiion of conntrack entries related to kubernetes cluster IP subnet.
+
 ### Configuration Options
 
 #### dns

--- a/infra-templates/network-services/27/README.md
+++ b/infra-templates/network-services/27/README.md
@@ -6,12 +6,13 @@ This stack provides the following services:
 * DNS
 * Network Manager
 
-### Changelog for v0.2.8
+### Changelog for v0.2.9
 
-#### Network Manager [rancher/network-manager:v0.7.19]
-* Fixed issue with a new host added takes time to be active
+#### Metadata [rancher/metadata:v0.10.1]
+* Added regions support
 
-#### Metadata [rancher/metadata:v0.9.5]
+#### DNS [rancher/dns:v0.17.1]
+* Added regions support
 
 ### Configuration Options
 

--- a/infra-templates/network-services/27/docker-compose.yml.tpl
+++ b/infra-templates/network-services/27/docker-compose.yml.tpl
@@ -1,0 +1,65 @@
+version: '2'
+
+{{- $netManagerImage:="rancher/network-manager:v0.7.19" }}
+{{- $metadataImage:="rancher/metadata:v0.9.5" }}
+{{- $dnsImage:="rancher/dns:v0.15.3" }}
+
+services:
+  network-manager:
+    image: {{$netManagerImage}}
+    privileged: true
+    network_mode: host
+    pid: host
+    command: plugin-manager --disable-cni-setup --metadata-address 169.254.169.250
+    environment:
+      DOCKER_BRIDGE: docker0
+      METADATA_IP: 169.254.169.250
+    volumes:
+    - /var/run/docker.sock:/var/run/docker.sock
+    - /var/lib/docker:/var/lib/docker
+    - /var/lib/rancher/state:/var/lib/rancher/state
+    - /lib/modules:/lib/modules:ro
+    - /run:/run
+    - /var/run:/var/run:ro
+    - rancher-cni-driver:/etc/cni
+    - rancher-cni-driver:/opt/cni
+    labels:
+      io.rancher.scheduler.global: 'true'
+    logging:
+      driver: json-file
+      options:
+        max-size: 25m
+        max-file: '2'
+  metadata:
+    cap_add:
+    - NET_ADMIN
+    image: {{$metadataImage}}
+    network_mode: bridge
+    command: start.sh rancher-metadata -reload-interval-limit=${RELOAD_INTERVAL_LIMIT} -subscribe
+    labels:
+      io.rancher.sidekicks: dns
+      io.rancher.container.create_agent: 'true'
+      io.rancher.scheduler.global: 'true'
+      io.rancher.container.agent_service.metadata: 'true'
+    logging:
+      driver: json-file
+      options:
+        max-size: 25m
+        max-file: '2'
+    sysctls:
+      net.ipv4.conf.all.send_redirects: '0'
+      net.ipv4.conf.default.send_redirects: '0'
+      net.ipv4.conf.eth0.send_redirects: '0'
+    cpu_period: ${CPU_PERIOD}
+    cpu_quota: ${CPU_QUOTA}
+  dns:
+    image: {{$dnsImage}}
+    network_mode: container:metadata
+    command: rancher-dns --listen 169.254.169.250:53 --metadata-server=localhost --answers=/etc/rancher-dns/answers.json --recurser-timeout ${DNS_RECURSER_TIMEOUT} --ttl ${TTL}
+    labels:
+      io.rancher.scheduler.global: 'true'
+    logging:
+      driver: json-file
+      options:
+        max-size: 25m
+        max-file: '2'

--- a/infra-templates/network-services/27/docker-compose.yml.tpl
+++ b/infra-templates/network-services/27/docker-compose.yml.tpl
@@ -2,7 +2,7 @@ version: '2'
 
 {{- $netManagerImage:="rancher/network-manager:v0.7.19" }}
 {{- $metadataImage:="rancher/metadata:v0.10.1" }}
-{{- $dnsImage:="rancher/dns:v0.17.1" }}
+{{- $dnsImage:="rancher/dns:v0.17.2" }}
 
 services:
   network-manager:

--- a/infra-templates/network-services/27/docker-compose.yml.tpl
+++ b/infra-templates/network-services/27/docker-compose.yml.tpl
@@ -1,8 +1,8 @@
 version: '2'
 
 {{- $netManagerImage:="rancher/network-manager:v0.7.19" }}
-{{- $metadataImage:="rancher/metadata:v0.9.5" }}
-{{- $dnsImage:="rancher/dns:v0.15.3" }}
+{{- $metadataImage:="rancher/metadata:v0.10.1" }}
+{{- $dnsImage:="rancher/dns:v0.17.1" }}
 
 services:
   network-manager:

--- a/infra-templates/network-services/27/docker-compose.yml.tpl
+++ b/infra-templates/network-services/27/docker-compose.yml.tpl
@@ -1,6 +1,6 @@
 version: '2'
 
-{{- $netManagerImage:="rancher/network-manager:v0.7.19" }}
+{{- $netManagerImage:="rancher/network-manager:v0.7.20" }}
 {{- $metadataImage:="rancher/metadata:v0.10.1" }}
 {{- $dnsImage:="rancher/dns:v0.17.2" }}
 

--- a/infra-templates/network-services/27/rancher-compose.yml
+++ b/infra-templates/network-services/27/rancher-compose.yml
@@ -1,0 +1,35 @@
+.catalog:
+    name: Network Services
+    version: v0.2.8
+    minimum_rancher_version: v1.6.13-rc1
+    questions:
+    - variable: DNS_RECURSER_TIMEOUT
+      label: Timeout for Rancher DNS Recurser
+      description: Specify timeout in seconds for DNS Recurser.
+      required: true
+      default: 2
+      type: int
+    - variable: TTL
+      label: TTL for service discovery answers
+      description: How long answers for *.rancher.internal responses are valid
+      required: true
+      default: 1
+      type: int
+    - variable: CPU_PERIOD
+      label: CPU scheduler period
+      description: Sets the period of CPUs to limit the metadata container's CPU usage
+      required: true
+      default: 400000
+      type: int
+    - variable: CPU_QUOTA
+      label: CPU quota on the metadata container
+      description: Sets the CPU quota on the metadata container
+      required: true
+      default: 200000
+      type: int
+    - variable: RELOAD_INTERVAL_LIMIT
+      label: Metadata reload interval limit
+      description: Limits reload to 1 per interval (milliseconds)
+      required: true
+      default: 1000
+      type: int

--- a/infra-templates/network-services/27/rancher-compose.yml
+++ b/infra-templates/network-services/27/rancher-compose.yml
@@ -1,7 +1,7 @@
 .catalog:
     name: Network Services
-    version: v0.2.8
-    minimum_rancher_version: v1.6.13-rc1
+    version: v0.2.9
+    minimum_rancher_version: v1.6.15-rc1
     questions:
     - variable: DNS_RECURSER_TIMEOUT
       label: Timeout for Rancher DNS Recurser

--- a/infra-templates/network-services/config.yml
+++ b/infra-templates/network-services/config.yml
@@ -1,5 +1,5 @@
 name: Network Services
-version: v0.2.8
+version: v0.2.9
 category: Framework
 labels:
   io.rancher.certified: rancher

--- a/infra-templates/nfs/4/rancher-compose.yml
+++ b/infra-templates/nfs/4/rancher-compose.yml
@@ -4,6 +4,7 @@
   description: |
     Docker volume plugin for NFS
   minimum_rancher_version: v1.6.6-rc1
+  maximum_rancher_version: v1.6.14
   questions:
   - variable: "NFS_SERVER"
     description: "IP or hostname of the default NFS Server"

--- a/infra-templates/nfs/5/docker-compose.yml
+++ b/infra-templates/nfs/5/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '2'
+services:
+  nfs-driver:
+    privileged: true
+    image: rancher/storage-nfs:v0.8.5
+    network_mode: host
+    labels:
+      io.rancher.scheduler.global: 'true'
+      io.rancher.container.create_agent: 'true'
+      io.rancher.container.agent.role: environment
+      io.rancher.container.dns: 'true'
+    environment:
+      NFS_SERVER: '${NFS_SERVER}'
+      MOUNT_DIR: '${MOUNT_DIR}'
+      MOUNT_OPTS: '${MOUNT_OPTS},${NFS_VERS}'
+      ON_REMOVE: '${ON_REMOVE}'
+      RANCHER_DEBUG: '${RANCHER_DEBUG}'
+    volumes:
+    - /run:/run
+    - /var/run:/var/run
+    - /dev:/host/dev
+    - /var/lib/rancher/volumes:/var/lib/rancher/volumes:shared
+    logging:
+      driver: json-file
+      options:
+        max-size: 25m
+        max-file: '2'

--- a/infra-templates/nfs/5/docker-compose.yml
+++ b/infra-templates/nfs/5/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
   nfs-driver:
     privileged: true
-    image: rancher/storage-nfs:v0.8.5
+    image: rancher/storage-nfs:v0.9.0
     network_mode: host
     labels:
       io.rancher.scheduler.global: 'true'

--- a/infra-templates/nfs/5/rancher-compose.yml
+++ b/infra-templates/nfs/5/rancher-compose.yml
@@ -1,0 +1,52 @@
+.catalog:
+  name: "Rancher NFS"
+  version: 0.4.0
+  description: |
+    Docker volume plugin for NFS
+  minimum_rancher_version: v1.6.6-rc1
+  questions:
+  - variable: "NFS_SERVER"
+    description: "IP or hostname of the default NFS Server"
+    label: "NFS Server"
+    required: true
+    type: "string"
+  - variable: "MOUNT_DIR"
+    label: "Export Base Directory"
+    description: "The default exported base directory"
+    type: "string"
+    required: true
+  - variable: "MOUNT_OPTS"
+    label: "Mount Options"
+    description: "Comma delimited list of default mount options, for example: 'proto=udp'. Do not specify `nfsvers` option, it will be ignored."
+    type: "string"
+  - variable: "NFS_VERS"
+    label: NFS Version
+    description: Default NFS version to use
+    type: enum
+    required: true
+    default: nfsvers=4
+    options:
+    - nfsvers=4
+    - nfsvers=3
+  - variable: ON_REMOVE
+    label: On Remove
+    description: On removal of Rancher NFS volume, should the underlying data be retained or purged.
+    type: enum
+    required: true
+    default: purge
+    options:
+    - purge
+    - retain
+  - variable: RANCHER_DEBUG
+    label: Debug Mode
+    type: enum
+    description: Enable or disable verbose logging
+    default: false
+    options:
+    - true
+    - false
+nfs-driver:
+  storage_driver:
+    name: rancher-nfs
+    scope: environment
+    volume_access_mode: multiHostRW

--- a/infra-templates/nfs/5/rancher-compose.yml
+++ b/infra-templates/nfs/5/rancher-compose.yml
@@ -1,9 +1,9 @@
 .catalog:
   name: "Rancher NFS"
-  version: 0.4.0
+  version: 0.5.0
   description: |
     Docker volume plugin for NFS
-  minimum_rancher_version: v1.6.6-rc1
+  minimum_rancher_version: v1.6.15-rc1
   questions:
   - variable: "NFS_SERVER"
     description: "IP or hostname of the default NFS Server"

--- a/infra-templates/nfs/config.yml
+++ b/infra-templates/nfs/config.yml
@@ -1,7 +1,7 @@
 name: Rancher NFS
 description: |
   Docker volume plugin for NFS. Supported for NFS v3 and v4.
-version: 0.4.0
+version: 0.5.0
 category: Storage
 labels:
   io.rancher.certified: rancher

--- a/infra-templates/secrets-bridge-v2/0/rancher-compose.yml
+++ b/infra-templates/secrets-bridge-v2/0/rancher-compose.yml
@@ -3,6 +3,7 @@
     version: v0.1.1
     description: "Volume plugin to fetch and present access tokens to Hashicorp Vault to the container"
     minimum_rancher_version: v1.6.13-rc1
+    maximum_rancher_version: v1.6.14
     questions:
       - variable: vault_url
         label: Vault URL

--- a/infra-templates/secrets-bridge-v2/1/docker-compose.yml
+++ b/infra-templates/secrets-bridge-v2/1/docker-compose.yml
@@ -1,0 +1,35 @@
+version: '2'
+services:
+  secrets-bridge-v2-server:
+    image: rancher/secrets-bridge-v2:v0.1.1
+    labels:
+      io.rancher.container.agent.role: environment
+      io.rancher.container.create_agent: 'true'
+    command: secrets-bridge-v2-server server --vault-url {{.Values.vault_url}} --vault-role {{.Values.vault_role}} --vault-token-file /run/secrets/{{.Values.issuing_token}}
+    secrets:
+      - "{{.Values.issuing_token}}"
+    
+  secrets-bridge-v2-driver:
+    privileged: true
+    image: rancher/storage-secrets-bridge-v2:v0.8.13
+    network_mode: host
+    environment:
+        VAULT_TOKEN_SERVER_URL: http://secrets-bridge-v2-server:8080/v1-vault-driver/tokens
+    volumes:
+    - /var/run:/var/run
+    - /dev:/host/dev
+    - /var/lib/rancher/volumes:/var/lib/rancher/volumes:shared
+    logging:
+      driver: json-file
+      options:
+        max-file: '2'
+        max-size: 25m
+    labels:
+      io.rancher.container.agent.role: environment
+      io.rancher.container.create_agent: 'true'
+      io.rancher.scheduler.global: 'true'
+      io.rancher.container.dns: 'true'
+
+secrets:
+  {{.Values.issuing_token}}:
+    external: true

--- a/infra-templates/secrets-bridge-v2/1/docker-compose.yml
+++ b/infra-templates/secrets-bridge-v2/1/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   secrets-bridge-v2-server:
-    image: rancher/secrets-bridge-v2:v0.1.1
+    image: rancher/secrets-bridge-v2:v0.2.0
     labels:
       io.rancher.container.agent.role: environment
       io.rancher.container.create_agent: 'true'

--- a/infra-templates/secrets-bridge-v2/1/docker-compose.yml
+++ b/infra-templates/secrets-bridge-v2/1/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     
   secrets-bridge-v2-driver:
     privileged: true
-    image: rancher/storage-secrets-bridge-v2:v0.8.13
+    image: rancher/storage-secrets-bridge-v2:v0.9.0
     network_mode: host
     environment:
         VAULT_TOKEN_SERVER_URL: http://secrets-bridge-v2-server:8080/v1-vault-driver/tokens

--- a/infra-templates/secrets-bridge-v2/1/rancher-compose.yml
+++ b/infra-templates/secrets-bridge-v2/1/rancher-compose.yml
@@ -1,0 +1,39 @@
+.catalog:
+    name: "Rancher Secrets Bridge V2"
+    version: v0.1.1
+    description: "Volume plugin to fetch and present access tokens to Hashicorp Vault to the container"
+    minimum_rancher_version: v1.6.13-rc1
+    questions:
+      - variable: vault_url
+        label: Vault URL
+        type: string
+        description: "URL for Hashicorp Vault server endpoint. Include http(s)"
+        required: true
+      - variable: vault_role
+        label: Vault Role
+        type: string
+        description: "Role that issuing token is assigned in Hashicorp Vault"
+        required: true
+      - variable: issuing_token
+        label: Issuing Token Secret
+        type: secret
+        description: "Secret containing issuing token"
+        required: true
+secrets-bridge-v2-server:
+  health_check:
+      response_timeout: 2000
+      healthy_threshold: 2
+      port: 8080
+      unhealthy_threshold: 3
+      initializing_timeout: 60000
+      interval: 2000
+      strategy: none
+      request_line: GET "/healthcheck" "HTTP/1.0"
+      reinitializing_timeout: 60000
+secrets-bridge-v2-driver:
+  storage_driver:
+    name: secrets-bridge-v2
+    description: "Secrets Bridge V2"
+    scope: local
+    volume_access_mode: singleHostRW
+    start_on_create: true

--- a/infra-templates/secrets-bridge-v2/1/rancher-compose.yml
+++ b/infra-templates/secrets-bridge-v2/1/rancher-compose.yml
@@ -1,8 +1,8 @@
 .catalog:
     name: "Rancher Secrets Bridge V2"
-    version: v0.1.1
+    version: v0.2.0
     description: "Volume plugin to fetch and present access tokens to Hashicorp Vault to the container"
-    minimum_rancher_version: v1.6.13-rc1
+    minimum_rancher_version: v1.6.15-rc1
     questions:
       - variable: vault_url
         label: Vault URL

--- a/infra-templates/secrets-bridge-v2/config.yml
+++ b/infra-templates/secrets-bridge-v2/config.yml
@@ -1,7 +1,7 @@
 name: Rancher Vault Volume Driver
 description: |
   Rancher Volume plugin
-version: v0.1.1
+version: v0.2.0
 category: Storage
 labels:
   io.rancher.certified: Experimental

--- a/infra-templates/secrets/1/rancher-compose.yml
+++ b/infra-templates/secrets/1/rancher-compose.yml
@@ -3,6 +3,7 @@
     version: v0.0.2
     description: "Volume plugin to fetch and present secrets through files on tmpfs"
     minimum_rancher_version: v1.5.0-rc1
+    maximum_rancher_version: v1.6.14
 secrets-driver:
   storage_driver:
     name: rancher-secrets

--- a/infra-templates/secrets/2/docker-compose.yml
+++ b/infra-templates/secrets/2/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '2'
+services:
+  secrets-driver:
+    privileged: true
+    image: rancher/storage-secrets:v0.6.8
+    network_mode: host
+    environment:
+        RANCHER_DEBUG: true
+    volumes:
+    - /var/run:/var/run
+    - /dev:/host/dev
+    - /var/lib/rancher/volumes:/var/lib/rancher/volumes:shared
+    logging:
+      driver: json-file
+      options:
+        max-file: '2'
+        max-size: 25m
+    labels:
+      io.rancher.container.agent.role: environment,agent
+      io.rancher.container.create_agent: 'true'
+      io.rancher.scheduler.global: 'true'

--- a/infra-templates/secrets/2/docker-compose.yml
+++ b/infra-templates/secrets/2/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
   secrets-driver:
     privileged: true
-    image: rancher/storage-secrets:v0.6.8
+    image: rancher/storage-secrets:v0.9.0
     network_mode: host
     environment:
         RANCHER_DEBUG: true

--- a/infra-templates/secrets/2/rancher-compose.yml
+++ b/infra-templates/secrets/2/rancher-compose.yml
@@ -1,0 +1,15 @@
+.catalog:
+    name: "Rancer Secrets"
+    version: v0.0.2
+    description: "Volume plugin to fetch and present secrets through files on tmpfs"
+    minimum_rancher_version: v1.5.0-rc1
+secrets-driver:
+  storage_driver:
+    name: rancher-secrets
+    description: "A tmpfs driver for secrets"
+    scope: local
+    create_supported: false
+    volume_access_mode: singleHostRW
+    volume_capabilities:
+      - secrets
+    start_on_create: true

--- a/infra-templates/secrets/2/rancher-compose.yml
+++ b/infra-templates/secrets/2/rancher-compose.yml
@@ -1,8 +1,8 @@
 .catalog:
     name: "Rancer Secrets"
-    version: v0.0.2
+    version: v0.0.3
     description: "Volume plugin to fetch and present secrets through files on tmpfs"
-    minimum_rancher_version: v1.5.0-rc1
+    minimum_rancher_version: v1.6.15-rc1
 secrets-driver:
   storage_driver:
     name: rancher-secrets

--- a/infra-templates/secrets/config.yml
+++ b/infra-templates/secrets/config.yml
@@ -1,7 +1,7 @@
 name: Rancher Secrets
 description: |
   Rancher Volume plugin
-version: v0.0.2
+version: v0.0.3
 category: Storage
 labels:
   io.rancher.certified: Experimental


### PR DESCRIPTION
ecr's `docker-compose` use lower-case (aws_access_key_id)
route53 use upper_case (AWS_ACCESS_KEY_ID)

I think upper case is better because it is the same with key (key of key-value in `docker-compose`)

please make them consistent.