### PR TITLE
Fix dns service will recursively search dns name in Windows DNS service

### DIFF
--- a/infra-templates/windows-network-services/1/README.md
+++ b/infra-templates/windows-network-services/1/README.md
@@ -1,0 +1,20 @@
+## Network Services for windows
+
+This stack provides the following services:
+
+* Metadata
+* DNS
+
+#### Metadata [rancher/metadata-windows:v0.10.0]
+* Use microsoft/nanoserver as base image and rebuild metadata service.
+
+#### DNS [rancher/dns-windows:v0.17.0]
+* Use microsoft/nanoserver as base image and rebuild DNS service.
+* In Windows environment, DNS server address will be 169.254.169.251
+
+### Configuration Options
+
+#### dns
+
+* `DNS_RECURSER_TIMEOUT`
+* `TTL`

--- a/infra-templates/windows-network-services/1/README.md
+++ b/infra-templates/windows-network-services/1/README.md
@@ -5,12 +5,10 @@ This stack provides the following services:
 * Metadata
 * DNS
 
-#### Metadata [rancher/metadata-windows:v0.10.0]
-* Use microsoft/nanoserver as base image and rebuild metadata service.
+### Changelog for v0.2.0
 
 #### DNS [rancher/dns-windows:v0.17.0]
-* Use microsoft/nanoserver as base image and rebuild DNS service.
-* In Windows environment, DNS server address will be 169.254.169.251
+* Add Parameter `--never-recurse-to=169.254.169.251` to DNS service
 
 ### Configuration Options
 

--- a/infra-templates/windows-network-services/1/docker-compose.yml.tpl
+++ b/infra-templates/windows-network-services/1/docker-compose.yml.tpl
@@ -1,0 +1,40 @@
+{{- $windowsMetadataImage:="rancher/metadata-windows:v0.10.0"}}
+{{- $windowsDNSImage:="rancher/dns-windows:v0.17.0"}}
+
+version: '2'
+services:
+  windows-metadata:
+    cap_add:
+    - NET_ADMIN
+    image: {{$windowsMetadataImage}}
+    network_mode: transparent
+    labels:
+      io.rancher.container.create_agent: "true"
+      io.rancher.container.agent.volumes_strategy: "skip"
+      io.rancher.container.create_agent_label: "no"
+      io.rancher.scheduler.affinity:host_label: io.rancher.host.os=windows
+      io.rancher.scheduler.global: 'true'
+      io.rancher.container.agent_service.metadata: 'true'
+    logging:
+      driver: json-file
+      options:
+        max-size: 25m
+        max-file: '2'
+    sysctls:
+      net.ipv4.conf.all.send_redirects: '0'
+      net.ipv4.conf.default.send_redirects: '0'
+      net.ipv4.conf.eth0.send_redirects: '0'
+  windows-dns:
+    image: {{$windowsDNSImage}}
+    network_mode: transparent
+    command: c:\\rancher-dns.exe --listen=169.254.169.251:53 --metadata-server=169.254.169.250:80 --answers=C:\\answers.json --recurser-timeout=${DNS_RECURSER_TIMEOUT} --ttl=${TTL}
+    labels:
+      io.rancher.scheduler.affinity:host_label: io.rancher.host.os=windows
+      io.rancher.scheduler.global: 'true'
+    links:
+    - windows-metadata
+    logging:
+      driver: json-file
+      options:
+        max-size: 25m
+        max-file: '2'

--- a/infra-templates/windows-network-services/1/docker-compose.yml.tpl
+++ b/infra-templates/windows-network-services/1/docker-compose.yml.tpl
@@ -27,7 +27,7 @@ services:
   windows-dns:
     image: {{$windowsDNSImage}}
     network_mode: transparent
-    command: c:\\rancher-dns.exe --listen=169.254.169.251:53 --metadata-server=169.254.169.250:80 --answers=C:\\answers.json --recurser-timeout=${DNS_RECURSER_TIMEOUT} --ttl=${TTL}
+    command: c:\\rancher-dns.exe --listen=169.254.169.251:53 --metadata-server=169.254.169.250:80 --answers=C:\\answers.json --recurser-timeout=${DNS_RECURSER_TIMEOUT} --ttl=${TTL} --never-recurse-to=169.254.169.251
     labels:
       io.rancher.scheduler.affinity:host_label: io.rancher.host.os=windows
       io.rancher.scheduler.global: 'true'

--- a/infra-templates/windows-network-services/1/rancher-compose.yml
+++ b/infra-templates/windows-network-services/1/rancher-compose.yml
@@ -1,0 +1,17 @@
+.catalog:
+    name: Network Services for Windows
+    version: v0.1.0
+    minimum_rancher_version: v1.6.13-rc1
+    questions:
+    - variable: DNS_RECURSER_TIMEOUT
+      label: Timeout for Rancher DNS Recurser
+      description: Specify timeout in seconds for DNS Recurser.
+      required: true
+      default: 2
+      type: int
+    - variable: TTL
+      label: TTL for service discovery answers
+      description: How long answers for *.rancher.internal responses are valid
+      required: true
+      default: 1
+      type: int

--- a/infra-templates/windows-network-services/1/rancher-compose.yml
+++ b/infra-templates/windows-network-services/1/rancher-compose.yml
@@ -1,7 +1,7 @@
 .catalog:
     name: Network Services for Windows
-    version: v0.1.0
-    minimum_rancher_version: v1.6.13-rc1
+    version: v0.2.0
+    minimum_rancher_version: v1.6.15-rc1
     questions:
     - variable: DNS_RECURSER_TIMEOUT
       label: Timeout for Rancher DNS Recurser

--- a/infra-templates/windows-network-services/config.yml
+++ b/infra-templates/windows-network-services/config.yml
@@ -1,5 +1,5 @@
 name: Windows Network Services
-version: v0.1.0
+version: v0.2.0
 category: Framework
 labels:
   io.rancher.certified: Experimental


### PR DESCRIPTION
Related issues
https://github.com/rancher/rancher/issues/12059
https://github.com/rancher/rancher/issues/11789

Add `--never-recurse-to=169.254.169.251` to dns parameter to solve the problem.