### PR TITLE
Adding changes for support for making FlexVolume Working

### DIFF
--- a/infra-templates/k8s/45/docker-compose.yml.tpl
+++ b/infra-templates/k8s/45/docker-compose.yml.tpl
@@ -68,7 +68,6 @@ kubelet:
         - rancher-cni-driver:/etc/cni:ro
         - rancher-cni-driver:/opt/cni:ro
         - /dev:/host/dev:rprivate
-        - /usr/libexec/kubernetes/kubelet-plugins:/usr/libexec/kubernetes/kubelet-plugins
     net: host
     pid: host
     ipc: host

--- a/infra-templates/k8s/45/docker-compose.yml.tpl
+++ b/infra-templates/k8s/45/docker-compose.yml.tpl
@@ -32,6 +32,7 @@ kubelet:
         - --network-plugin=cni
         - --cni-conf-dir=/etc/cni/managed.d
         - --anonymous-auth=false
+        - --volume-plugin-dir=/var/lib/kubelet/volumeplugins
         - --client-ca-file=/etc/kubernetes/ssl/ca.pem
         {{- if and (ne .Values.REGISTRY "") (ne .Values.POD_INFRA_CONTAINER_IMAGE "") }}
         - --pod-infra-container-image=${REGISTRY}/${POD_INFRA_CONTAINER_IMAGE}
@@ -67,6 +68,7 @@ kubelet:
         - rancher-cni-driver:/etc/cni:ro
         - rancher-cni-driver:/opt/cni:ro
         - /dev:/host/dev:rprivate
+        - /usr/libexec/kubernetes/kubelet-plugins:/usr/libexec/kubernetes/kubelet-plugins
     net: host
     pid: host
     ipc: host

--- a/infra-templates/k8s/45/docker-compose.yml.tpl
+++ b/infra-templates/k8s/45/docker-compose.yml.tpl
@@ -67,6 +67,7 @@ kubelet:
         - rancher-cni-driver:/etc/cni:ro
         - rancher-cni-driver:/opt/cni:ro
         - /dev:/host/dev:rprivate
+        - /usr/libexec/kubernetes/kubelet-plugins:/usr/libexec/kubernetes/kubelet-plugins
     net: host
     pid: host
     ipc: host

--- a/infra-templates/k8s/45/docker-compose.yml.tpl
+++ b/infra-templates/k8s/45/docker-compose.yml.tpl
@@ -32,6 +32,7 @@ kubelet:
         - --network-plugin=cni
         - --cni-conf-dir=/etc/cni/managed.d
         - --anonymous-auth=false
+        - --volume-plugin-dir=/var/lib/kubelet/volumeplugins
         - --client-ca-file=/etc/kubernetes/ssl/ca.pem
         {{- if and (ne .Values.REGISTRY "") (ne .Values.POD_INFRA_CONTAINER_IMAGE "") }}
         - --pod-infra-container-image=${REGISTRY}/${POD_INFRA_CONTAINER_IMAGE}

--- a/infra-templates/k8s/45/docker-compose.yml.tpl
+++ b/infra-templates/k8s/45/docker-compose.yml.tpl
@@ -32,6 +32,7 @@ kubelet:
         - --network-plugin=cni
         - --cni-conf-dir=/etc/cni/managed.d
         - --anonymous-auth=false
+        - --volume-plugin-dir=/var/lib/kubelet/volumeplugins
         - --client-ca-file=/etc/kubernetes/ssl/ca.pem
         {{- if and (ne .Values.REGISTRY "") (ne .Values.POD_INFRA_CONTAINER_IMAGE "") }}
         - --pod-infra-container-image=${REGISTRY}/${POD_INFRA_CONTAINER_IMAGE}
@@ -67,7 +68,6 @@ kubelet:
         - rancher-cni-driver:/etc/cni:ro
         - rancher-cni-driver:/opt/cni:ro
         - /dev:/host/dev:rprivate
-        - /usr/libexec/kubernetes/kubelet-plugins:/usr/libexec/kubernetes/kubelet-plugins
     net: host
     pid: host
     ipc: host


### PR DESCRIPTION
This is related to issue in longhorn https://github.com/rancher/longhorn/issues/54 
Affects other storage drivers too like OpenEBS

Without this kubelet running as container in Rancher 1.6.5 can not access the directory /usr/libexec/kubernetes/kubelet-plugins and hence the storage volumes like longhorn do not work properly.