### PR TITLE
Set default cipher suit for kubeapi and kubelet

### DIFF
--- a/infra-templates/k8s/45/docker-compose.yml.tpl
+++ b/infra-templates/k8s/45/docker-compose.yml.tpl
@@ -38,6 +38,7 @@ kubelet:
         {{- else if (ne .Values.POD_INFRA_CONTAINER_IMAGE "") }}
         - --pod-infra-container-image=${POD_INFRA_CONTAINER_IMAGE}
         {{- end }}
+        - --tls-cipher-suites=${KUBERNETES_CIPHER_SUITES}
         {{- range $i, $elem := splitPreserveQuotes .Values.ADDITIONAL_KUBELET_FLAGS }}
         - {{ $elem }}
         {{- end }}
@@ -104,6 +105,7 @@ kubelet-unschedulable:
         - --pod-infra-container-image=${POD_INFRA_CONTAINER_IMAGE}
         {{- end }}
         - --register-schedulable=false
+        - --tls-cipher-suites=${KUBERNETES_CIPHER_SUITES}
         {{- range $i, $elem := splitPreserveQuotes .Values.ADDITIONAL_KUBELET_FLAGS }}
         - {{ $elem }}
         {{- end }}
@@ -230,9 +232,7 @@ kubernetes:
         {{- if eq .Values.RBAC "true" }}
         - --authorization-mode=RBAC
         {{- end }}
-        {{- if ne .Values.KUBEAPI_CIPHER_SUITES "" }}
-        - --tls-cipher-suites=${KUBEAPI_CIPHER_SUITES}
-        {{- end }}
+        - --tls-cipher-suites=${KUBERNETES_CIPHER_SUITES}
     environment:
         KUBERNETES_URL: https://kubernetes.kubernetes.rancher.internal:6443
         {{- if ne .Values.HTTP_PROXY "" }}

--- a/infra-templates/k8s/45/rancher-compose.yml
+++ b/infra-templates/k8s/45/rancher-compose.yml
@@ -178,10 +178,11 @@
     required: true
     default: "10.43.0.1"
     type: string
-  - variable: KUBEAPI_CIPHER_SUITES
-    label: KubeAPI cipher suites
-    description: A comma-separated list of TLS cipher suites to be used by kubernetes api server. Available values can be found in (https://golang.org/pkg/crypto/tls/#pkg-constants). If not set, the default Go cipher suites will be used.
-    required: false
+  - variable: KUBERNETES_CIPHER_SUITES
+    label: Kubernetes cipher suites
+    description: A comma-separated list of TLS cipher suites to be used by kubernetes api server and kubelet. Available values can be found in (https://golang.org/pkg/crypto/tls/#pkg-constants). The default list is a list of the currently most secure cipher suites.
+    required: true
+    default: "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305"
     type: string
   - variable: DASHBOARD_CPU_LIMIT
     label: Kubernetes Dashboard CPU limit


### PR DESCRIPTION
Set the secure cipher list to resolve: https://github.com/rancher/rancher/issues/10354

Test results using https://testssl.sh/ : 
```
 Testing vulnerabilities 

 Heartbleed (CVE-2014-0160)                not vulnerable (OK), no heartbeat extension
 CCS (CVE-2014-0224)                       not vulnerable (OK)
 Ticketbleed (CVE-2016-9244), experiment.  not vulnerable (OK)
 Secure Renegotiation (CVE-2009-3555)      not vulnerable (OK)
 Secure Client-Initiated Renegotiation     not vulnerable (OK)
 CRIME, TLS (CVE-2012-4929)                not vulnerable (OK)
 BREACH (CVE-2013-3587)                    no HTTP compression (OK)  - only supplied "/" tested
 POODLE, SSL (CVE-2014-3566)               not vulnerable (OK)
 TLS_FALLBACK_SCSV (RFC 7507)              No fallback possible, TLS 1.2 is the only protocol (OK)
 SWEET32 (CVE-2016-2183, CVE-2016-6329)    not vulnerable (OK)
 FREAK (CVE-2015-0204)                     not vulnerable (OK)
 DROWN (CVE-2016-0800, CVE-2016-0703)      not vulnerable on this host and port (OK)
                                           make sure you don't use this certificate elsewhere with SSLv2 enabled services
                                           https://censys.io/ipv4?q=47FE8E45D430AD99DB28D00F64C1FCD0CA2285C6C83D392AA800AD70BADC07D3 could help you to find out
 LOGJAM (CVE-2015-4000), experimental      not vulnerable (OK): no DH EXPORT ciphers, no DH key detected
 BEAST (CVE-2011-3389)                     no SSL3 or TLS1 (OK)
 LUCKY13 (CVE-2013-0169), experimental     not vulnerable (OK)
 RC4 (CVE-2013-2566, CVE-2015-2808)        no RC4 ciphers detected (OK)
```