### PR TITLE
Portworx versions catchup 3b

### DIFF
--- a/infra-templates/portworx/18/README.md
+++ b/infra-templates/portworx/18/README.md
@@ -1,0 +1,34 @@
+# Volume plugin for Portworx
+
+This version of [Portworx](https://docs.portworx.com) stack will transparently download and install [Portworx runC container](https://docs.portworx.com/runc), which runs directly on the host as a service.
+
+## Prerequisites
+
+* **Key-value store**: Portworx uses a key-value store for it's clustering metadata. Please have a clustered key-value database (etcd or consul) installed and ready before starting the Portworx installation. For etcd installation instructions please refer to this [doc](https://docs.portworx.com/maintain/etcd.html).
+* **Storage**: At least one of the Portworx nodes should have extra storage available, in a form of unformatted partition or a disk-drive.<br/>NOTE: Storage devices explicitly given to Portworx via `-s /dev/xxx` will be automatically formatted by PX.
+* **Firewall**: Ensure ports 9001-9015 are open between the nodes that will run Portworx.
+* **NTP**: Ensure all nodes running PX are time-synchronized, and NTP service is configured and running.
+* **Hosts**: The systemd package should be installed and available on all host systems.  If your hosts are running Ubuntu 16, CentoOS 7 or CoreOS v94 (or newer) the “systemd” is already installed and no actions will be required.
+
+## Installation
+
+To install Portworx, please enter the "Configuration Options" below, and click on "Launch".
+
+Please note that the Portworx will by default install as a [global service](http://rancher.com/docs/rancher/latest/en/cattle/scheduling/#global-service)
+to *all Racher hoots* in your environment.  If you need to avoid installing Portworx on certain hosts, edit the individual Hosts using Rancher GUI via "INFRASTRUCTURE / Hosts / : / Edit", and attach the `px/enabled=false` label to the given host.
+
+Please note that the "Configuration Options" below show only a minimum of customization options.  Refer to the [#command-line-arguments page](https://docs.portworx.com/runc/#command-line-arguments) page for the full set of supported options.  Extra options can be added "verbatim" into the `Extra Options` field below.
+
+## Uninstallation
+
+Please note that Rancher will forbid the uninstall of Portworx stack as long as there are any containers or volumes still present in Rancher environment.
+
+If you want to completely remove the Portworx from Rancher, it will not be sufficient to remove only the Portworx stack, since Portworx OCI service will continue running on the host system as "systemd service".  To remove the Portworx software, including the Portworx systemd service, please run the following:
+
+```
+for id in $(rancher ps -q -s portworx/portworx); do
+  rancher exec $id /px-rest-helper.sh remove
+done
+rancher rm -s portworx/portworx; sleep 5
+rancher rm -s portworx
+```

--- a/infra-templates/portworx/18/docker-compose.yml.tpl
+++ b/infra-templates/portworx/18/docker-compose.yml.tpl
@@ -1,0 +1,29 @@
+version: '2'
+services:
+  portworx:
+    image: portworx/oci-monitor:1.4.2.1
+    container_name: px-oci-mon
+    privileged: true
+    labels:
+      io.rancher.container.dns: 'true'
+      {{- if eq .Values.INSTALL_SCALE "global" }}
+      io.rancher.scheduler.global: 'true'
+      {{- end }}
+      io.rancher.container.pull_image: always
+      io.rancher.container.hostname_override: container_name
+      io.rancher.scheduler.affinity:container_label_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
+      io.rancher.scheduler.affinity:host_label_ne: px/enabled=false
+    environment:
+      CLUSTER_ID: ${CLUSTER_ID}
+      KVDB: ${KVDB}
+      USE_DISKS: ${USE_DISKS}
+      EXTRA_OPTS: ${EXTRA_OPTS}
+      ENABLE_ATTR_CACHE: true
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:rprivate
+      - /etc/pwx:/etc/pwx:rprivate
+      - /opt/pwx:/opt/pwx:rprivate
+      - /etc/systemd/system:/etc/systemd/system:rprivate
+      - /proc/1/ns:/host_proc/1/ns:rprivate
+      - /var/run/dbus:/var/run/dbus:rprivate
+    command: -c ${CLUSTER_ID} -k ${KVDB} ${USE_DISKS} -x rancher --endpoint 0.0.0.0:9015 ${EXTRA_OPTS}

--- a/infra-templates/portworx/18/rancher-compose.yml
+++ b/infra-templates/portworx/18/rancher-compose.yml
@@ -1,0 +1,62 @@
+.catalog:
+  name: "Portworx"
+  version: "1.4.2.1-oci"
+  description: "Portworx Docker Volume Driver"
+  questions:
+
+    - variable: INSTALL_SCALE
+      label: Install scale
+      description: "Determine if Portworx should install globally on all the nodes, or scaled via stacks (starting with Scale=1)."
+      required: true
+      default: "global"
+      type: enum
+      options:
+      - "global"
+      - "scaled"
+    - variable: "CLUSTER_ID"
+      description: "Arbitrary Cluster ID, common to all nodes in PX cluster "
+      label: "Cluster ID"
+      type: "string"
+      required: true
+      default: ""
+    - variable: "KVDB"
+      description: "Key-value database, accessibe to all nodes in PX cluster"
+      label: "Key-Value Database"
+      type: "string"
+      required: true
+      default: ""
+    - variable: "USE_DISKS"
+      description: "Specify which disks to use (Ex: '-a' for all available unformatted disks, or '-s /dev/sdX' for each individual disk)"
+      label: "Use Disks"
+      type: "string"
+      required: true
+      default: "-a"
+    - variable: "EXTRA_OPTS"
+      description: "Extra portworx options (see https://docs.portworx.com/runc/#command-line-arguments)"
+      label: "Extra Options"
+      type: "string"
+      required: false
+      default: ""
+
+portworx:
+  metadata:
+    version: 1
+    storageDriverName: pxd
+    debug: true
+    volumeDriverName: pxd
+  storage_driver:
+    name: pxd
+    scope: environment
+    volume_access_mode: multiHostRW
+    blockDevicePath: null
+  start_on_create: true
+  health_check:
+    request_line: GET /health HTTP/1.0
+    port: 9015
+    interval: 10000
+    response_timeout: 5000
+    unhealthy_threshold: 3
+    healthy_threshold: 2
+    initializing_timeout: 840000
+    strategy: none
+

--- a/infra-templates/portworx/19/README.md
+++ b/infra-templates/portworx/19/README.md
@@ -1,0 +1,34 @@
+# Volume plugin for Portworx
+
+This version of [Portworx](https://docs.portworx.com) stack will transparently download and install [Portworx runC container](https://docs.portworx.com/runc), which runs directly on the host as a service.
+
+## Prerequisites
+
+* **Key-value store**: Portworx uses a key-value store for it's clustering metadata. Please have a clustered key-value database (etcd or consul) installed and ready before starting the Portworx installation. For etcd installation instructions please refer to this [doc](https://docs.portworx.com/maintain/etcd.html).
+* **Storage**: At least one of the Portworx nodes should have extra storage available, in a form of unformatted partition or a disk-drive.<br/>NOTE: Storage devices explicitly given to Portworx via `-s /dev/xxx` will be automatically formatted by PX.
+* **Firewall**: Ensure ports 9001-9015 are open between the nodes that will run Portworx.
+* **NTP**: Ensure all nodes running PX are time-synchronized, and NTP service is configured and running.
+* **Hosts**: The systemd package should be installed and available on all host systems.  If your hosts are running Ubuntu 16, CentoOS 7 or CoreOS v94 (or newer) the “systemd” is already installed and no actions will be required.
+
+## Installation
+
+To install Portworx, please enter the "Configuration Options" below, and click on "Launch".
+
+Please note that the Portworx will by default install as a [global service](http://rancher.com/docs/rancher/latest/en/cattle/scheduling/#global-service)
+to *all Racher hoots* in your environment.  If you need to avoid installing Portworx on certain hosts, edit the individual Hosts using Rancher GUI via "INFRASTRUCTURE / Hosts / : / Edit", and attach the `px/enabled=false` label to the given host.
+
+Please note that the "Configuration Options" below show only a minimum of customization options.  Refer to the [#command-line-arguments page](https://docs.portworx.com/runc/#command-line-arguments) page for the full set of supported options.  Extra options can be added "verbatim" into the `Extra Options` field below.
+
+## Uninstallation
+
+Please note that Rancher will forbid the uninstall of Portworx stack as long as there are any containers or volumes still present in Rancher environment.
+
+If you want to completely remove the Portworx from Rancher, it will not be sufficient to remove only the Portworx stack, since Portworx OCI service will continue running on the host system as "systemd service".  To remove the Portworx software, including the Portworx systemd service, please run the following:
+
+```
+for id in $(rancher ps -q -s portworx/portworx); do
+  rancher exec $id /px-rest-helper.sh remove
+done
+rancher rm -s portworx/portworx; sleep 5
+rancher rm -s portworx
+```

--- a/infra-templates/portworx/19/docker-compose.yml.tpl
+++ b/infra-templates/portworx/19/docker-compose.yml.tpl
@@ -1,0 +1,29 @@
+version: '2'
+services:
+  portworx:
+    image: portworx/oci-monitor:1.4.2.2
+    container_name: px-oci-mon
+    privileged: true
+    labels:
+      io.rancher.container.dns: 'true'
+      {{- if eq .Values.INSTALL_SCALE "global" }}
+      io.rancher.scheduler.global: 'true'
+      {{- end }}
+      io.rancher.container.pull_image: always
+      io.rancher.container.hostname_override: container_name
+      io.rancher.scheduler.affinity:container_label_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
+      io.rancher.scheduler.affinity:host_label_ne: px/enabled=false
+    environment:
+      CLUSTER_ID: ${CLUSTER_ID}
+      KVDB: ${KVDB}
+      USE_DISKS: ${USE_DISKS}
+      EXTRA_OPTS: ${EXTRA_OPTS}
+      ENABLE_ATTR_CACHE: true
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:rprivate
+      - /etc/pwx:/etc/pwx:rprivate
+      - /opt/pwx:/opt/pwx:rprivate
+      - /etc/systemd/system:/etc/systemd/system:rprivate
+      - /proc/1/ns:/host_proc/1/ns:rprivate
+      - /var/run/dbus:/var/run/dbus:rprivate
+    command: -c ${CLUSTER_ID} -k ${KVDB} ${USE_DISKS} -x rancher --endpoint 0.0.0.0:9015 ${EXTRA_OPTS}

--- a/infra-templates/portworx/19/rancher-compose.yml
+++ b/infra-templates/portworx/19/rancher-compose.yml
@@ -1,0 +1,62 @@
+.catalog:
+  name: "Portworx"
+  version: "1.4.2.2-oci"
+  description: "Portworx Docker Volume Driver"
+  questions:
+
+    - variable: INSTALL_SCALE
+      label: Install scale
+      description: "Determine if Portworx should install globally on all the nodes, or scaled via stacks (starting with Scale=1)."
+      required: true
+      default: "global"
+      type: enum
+      options:
+      - "global"
+      - "scaled"
+    - variable: "CLUSTER_ID"
+      description: "Arbitrary Cluster ID, common to all nodes in PX cluster "
+      label: "Cluster ID"
+      type: "string"
+      required: true
+      default: ""
+    - variable: "KVDB"
+      description: "Key-value database, accessibe to all nodes in PX cluster"
+      label: "Key-Value Database"
+      type: "string"
+      required: true
+      default: ""
+    - variable: "USE_DISKS"
+      description: "Specify which disks to use (Ex: '-a' for all available unformatted disks, or '-s /dev/sdX' for each individual disk)"
+      label: "Use Disks"
+      type: "string"
+      required: true
+      default: "-a"
+    - variable: "EXTRA_OPTS"
+      description: "Extra portworx options (see https://docs.portworx.com/runc/#command-line-arguments)"
+      label: "Extra Options"
+      type: "string"
+      required: false
+      default: ""
+
+portworx:
+  metadata:
+    version: 1
+    storageDriverName: pxd
+    debug: true
+    volumeDriverName: pxd
+  storage_driver:
+    name: pxd
+    scope: environment
+    volume_access_mode: multiHostRW
+    blockDevicePath: null
+  start_on_create: true
+  health_check:
+    request_line: GET /health HTTP/1.0
+    port: 9015
+    interval: 10000
+    response_timeout: 5000
+    unhealthy_threshold: 3
+    healthy_threshold: 2
+    initializing_timeout: 840000
+    strategy: none
+

--- a/infra-templates/portworx/20/README.md
+++ b/infra-templates/portworx/20/README.md
@@ -1,0 +1,34 @@
+# Volume plugin for Portworx
+
+This version of [Portworx](https://docs.portworx.com) stack will transparently download and install [Portworx runC container](https://docs.portworx.com/runc), which runs directly on the host as a service.
+
+## Prerequisites
+
+* **Key-value store**: Portworx uses a key-value store for it's clustering metadata. Please have a clustered key-value database (etcd or consul) installed and ready before starting the Portworx installation. For etcd installation instructions please refer to this [doc](https://docs.portworx.com/maintain/etcd.html).
+* **Storage**: At least one of the Portworx nodes should have extra storage available, in a form of unformatted partition or a disk-drive.<br/>NOTE: Storage devices explicitly given to Portworx via `-s /dev/xxx` will be automatically formatted by PX.
+* **Firewall**: Ensure ports 9001-9015 are open between the nodes that will run Portworx.
+* **NTP**: Ensure all nodes running PX are time-synchronized, and NTP service is configured and running.
+* **Hosts**: The systemd package should be installed and available on all host systems.  If your hosts are running Ubuntu 16, CentoOS 7 or CoreOS v94 (or newer) the “systemd” is already installed and no actions will be required.
+
+## Installation
+
+To install Portworx, please enter the "Configuration Options" below, and click on "Launch".
+
+Please note that the Portworx will by default install as a [global service](http://rancher.com/docs/rancher/latest/en/cattle/scheduling/#global-service)
+to *all Racher hoots* in your environment.  If you need to avoid installing Portworx on certain hosts, edit the individual Hosts using Rancher GUI via "INFRASTRUCTURE / Hosts / : / Edit", and attach the `px/enabled=false` label to the given host.
+
+Please note that the "Configuration Options" below show only a minimum of customization options.  Refer to the [#command-line-arguments page](https://docs.portworx.com/runc/#command-line-arguments) page for the full set of supported options.  Extra options can be added "verbatim" into the `Extra Options` field below.
+
+## Uninstallation
+
+Please note that Rancher will forbid the uninstall of Portworx stack as long as there are any containers or volumes still present in Rancher environment.
+
+If you want to completely remove the Portworx from Rancher, it will not be sufficient to remove only the Portworx stack, since Portworx OCI service will continue running on the host system as "systemd service".  To remove the Portworx software, including the Portworx systemd service, please run the following:
+
+```
+for id in $(rancher ps -q -s portworx/portworx); do
+  rancher exec $id /px-rest-helper.sh remove
+done
+rancher rm -s portworx/portworx; sleep 5
+rancher rm -s portworx
+```

--- a/infra-templates/portworx/20/docker-compose.yml.tpl
+++ b/infra-templates/portworx/20/docker-compose.yml.tpl
@@ -1,0 +1,29 @@
+version: '2'
+services:
+  portworx:
+    image: portworx/oci-monitor:1.5.0
+    container_name: px-oci-mon
+    privileged: true
+    labels:
+      io.rancher.container.dns: 'true'
+      {{- if eq .Values.INSTALL_SCALE "global" }}
+      io.rancher.scheduler.global: 'true'
+      {{- end }}
+      io.rancher.container.pull_image: always
+      io.rancher.container.hostname_override: container_name
+      io.rancher.scheduler.affinity:container_label_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
+      io.rancher.scheduler.affinity:host_label_ne: px/enabled=false
+    environment:
+      CLUSTER_ID: ${CLUSTER_ID}
+      KVDB: ${KVDB}
+      USE_DISKS: ${USE_DISKS}
+      EXTRA_OPTS: ${EXTRA_OPTS}
+      ENABLE_ATTR_CACHE: true
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:rprivate
+      - /etc/pwx:/etc/pwx:rprivate
+      - /opt/pwx:/opt/pwx:rprivate
+      - /etc/systemd/system:/etc/systemd/system:rprivate
+      - /proc/1/ns:/host_proc/1/ns:rprivate
+      - /var/run/dbus:/var/run/dbus:rprivate
+    command: -c ${CLUSTER_ID} -k ${KVDB} ${USE_DISKS} -x rancher --endpoint 0.0.0.0:9015 ${EXTRA_OPTS}

--- a/infra-templates/portworx/20/rancher-compose.yml
+++ b/infra-templates/portworx/20/rancher-compose.yml
@@ -1,0 +1,62 @@
+.catalog:
+  name: "Portworx"
+  version: "1.5.0.0-oci"
+  description: "Portworx Docker Volume Driver"
+  questions:
+
+    - variable: INSTALL_SCALE
+      label: Install scale
+      description: "Determine if Portworx should install globally on all the nodes, or scaled via stacks (starting with Scale=1)."
+      required: true
+      default: "global"
+      type: enum
+      options:
+      - "global"
+      - "scaled"
+    - variable: "CLUSTER_ID"
+      description: "Arbitrary Cluster ID, common to all nodes in PX cluster "
+      label: "Cluster ID"
+      type: "string"
+      required: true
+      default: ""
+    - variable: "KVDB"
+      description: "Key-value database, accessibe to all nodes in PX cluster"
+      label: "Key-Value Database"
+      type: "string"
+      required: true
+      default: ""
+    - variable: "USE_DISKS"
+      description: "Specify which disks to use (Ex: '-a' for all available unformatted disks, or '-s /dev/sdX' for each individual disk)"
+      label: "Use Disks"
+      type: "string"
+      required: true
+      default: "-a"
+    - variable: "EXTRA_OPTS"
+      description: "Extra portworx options (see https://docs.portworx.com/runc/#command-line-arguments)"
+      label: "Extra Options"
+      type: "string"
+      required: false
+      default: ""
+
+portworx:
+  metadata:
+    version: 1
+    storageDriverName: pxd
+    debug: true
+    volumeDriverName: pxd
+  storage_driver:
+    name: pxd
+    scope: environment
+    volume_access_mode: multiHostRW
+    blockDevicePath: null
+  start_on_create: true
+  health_check:
+    request_line: GET /health HTTP/1.0
+    port: 9015
+    interval: 10000
+    response_timeout: 5000
+    unhealthy_threshold: 3
+    healthy_threshold: 2
+    initializing_timeout: 840000
+    strategy: none
+

--- a/infra-templates/portworx/config.yml
+++ b/infra-templates/portworx/config.yml
@@ -1,7 +1,7 @@
 name: Portworx
 description: |
   Volume plugin for Portworx Elastic Data Fabric, providing scale-out persistent storage for containers.
-version: "1.4.2.1-oci"
+version: "1.4.2.2-oci"
 category: Storage
 labels:
   io.rancher.orchestration.supported: 'cattle'

--- a/infra-templates/portworx/config.yml
+++ b/infra-templates/portworx/config.yml
@@ -1,7 +1,7 @@
 name: Portworx
 description: |
   Volume plugin for Portworx Elastic Data Fabric, providing scale-out persistent storage for containers.
-version: "1.4.2.0-oci"
+version: "1.4.2.1-oci"
 category: Storage
 labels:
   io.rancher.orchestration.supported: 'cattle'

--- a/infra-templates/portworx/config.yml
+++ b/infra-templates/portworx/config.yml
@@ -1,7 +1,7 @@
 name: Portworx
 description: |
   Volume plugin for Portworx Elastic Data Fabric, providing scale-out persistent storage for containers.
-version: "1.4.2.2-oci"
+version: "1.5.0.0-oci"
 category: Storage
 labels:
   io.rancher.orchestration.supported: 'cattle'


### PR DESCRIPTION
Adding the following portworx versions:
* 2f6e694 Adding Portworx v1.5.0.0 entry (Aug 22 2018)
* e699d8c Adding Portworx v1.4.2.2 entry (Aug 10 2018)
* 6dcb3b9 Adding Portworx v1.4.2.1 entry (Aug 1 2018)