### PR TITLE
Add max rancher version for scheduler template 12

### DIFF
--- a/infra-templates/scheduler/12/rancher-compose.yml
+++ b/infra-templates/scheduler/12/rancher-compose.yml
@@ -3,6 +3,7 @@
     description: A resource based scheduler plugin for Rancher.
     version: v0.8.5
     minimum_rancher_version: v1.6.19-rc1
+    maximum_rancher_version: v1.6.26
     questions:
         - variable: "RANCHER_DEBUG"
           label: "Enable Debug Logs"


### PR DESCRIPTION
Adding the maximum_rancher_version: v1.6.26, so that it does not show up when upgraded to 1.6.17-rc1

https://github.com/rancher/rancher/issues/19567